### PR TITLE
Document email nullability on User

### DIFF
--- a/src/main/java/discord4j/discordjson/json/UserData.java
+++ b/src/main/java/discord4j/discordjson/json/UserData.java
@@ -32,7 +32,6 @@ public interface UserData {
 
     default Possible<Boolean> verified() { return Possible.absent(); }
 
-    // TODO Ready can contain null email field!
     default Possible<Optional<String>> email() { return Possible.absent(); }
 
     default Possible<Integer> flags() { return Possible.absent(); }


### PR DESCRIPTION
**Description:** This is confirmed that this field is nullable.

**Justification:** https://github.com/discord/discord-api-docs/pull/1433