### PR TITLE
Update GuildMemberUpdate fields

### DIFF
--- a/src/main/java/discord4j/discordjson/json/gateway/GuildMemberUpdate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildMemberUpdate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import discord4j.discordjson.json.UserData;
+import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.util.List;
@@ -18,7 +19,7 @@ public interface GuildMemberUpdate extends Dispatch {
     String guildId();
     List<String> roles();
     UserData user();
-    Optional<String> nick();
+    Possible<Optional<String>> nick() { return Possible.absent(); };
     @JsonProperty("premium_since")
-    Optional<String> premiumSince();
+    Possible<Optional<String>> premiumSince() { return Possible.absent(); };
 }

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildMemberUpdate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildMemberUpdate.java
@@ -19,7 +19,7 @@ public interface GuildMemberUpdate extends Dispatch {
     String guildId();
     List<String> roles();
     UserData user();
-    Possible<Optional<String>> nick() { return Possible.absent(); };
+    Possible<Optional<String>> nick() { return Possible.absent(); }
     @JsonProperty("premium_since")
-    Possible<Optional<String>> premiumSince() { return Possible.absent(); };
+    Possible<Optional<String>> premiumSince() { return Possible.absent(); }
 }

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildMemberUpdate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildMemberUpdate.java
@@ -19,7 +19,7 @@ public interface GuildMemberUpdate extends Dispatch {
     String guildId();
     List<String> roles();
     UserData user();
-    Possible<Optional<String>> nick() { return Possible.absent(); }
+    default Possible<Optional<String>> nick() { return Possible.absent(); }
     @JsonProperty("premium_since")
-    Possible<Optional<String>> premiumSince() { return Possible.absent(); }
+    default Possible<Optional<String>> premiumSince() { return Possible.absent(); }
 }


### PR DESCRIPTION
**Description:** `nick` and `premium_since` fields are now possible in `GuildMemberUpdate` event.

**Justification:** https://github.com/discord/discord-api-docs/pull/1440