### PR TITLE
Refactor WebhookExecuteRequest and MessageCreateRequest so they extend common interface.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/src/main/java/discord4j/discordjson/json/MessageCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/MessageCreateRequest.java
@@ -1,6 +1,5 @@
 package discord4j.discordjson.json;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import discord4j.discordjson.possible.Possible;
@@ -9,16 +8,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableMessageCreateRequest.class)
 @JsonDeserialize(as = ImmutableMessageCreateRequest.class)
-public interface MessageCreateRequest {
-
+public interface MessageCreateRequest extends MessageSendRequestBase {
     static ImmutableMessageCreateRequest.Builder builder() {
         return ImmutableMessageCreateRequest.builder();
     }
 
-    Possible<String> content();
     Possible<Object> nonce();
-    Possible<Boolean> tts();
     Possible<EmbedData> embed();
-    @JsonProperty("allowed_mentions")
-    Possible<AllowedMentionsData> allowedMentions();
 }

--- a/src/main/java/discord4j/discordjson/json/MessageSendRequestBase.java
+++ b/src/main/java/discord4j/discordjson/json/MessageSendRequestBase.java
@@ -1,0 +1,11 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import discord4j.discordjson.possible.Possible;
+
+public interface MessageSendRequestBase {
+    Possible<String> content();
+    Possible<Boolean> tts();
+    @JsonProperty("allowed_mentions")
+    Possible<AllowedMentionsData> allowedMentions();
+}

--- a/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
+++ b/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
@@ -11,18 +11,14 @@ import java.util.List;
 @Value.Immutable
 @JsonSerialize(as = ImmutableWebhookExecuteRequest.class)
 @JsonDeserialize(as = ImmutableWebhookExecuteRequest.class)
-public interface WebhookExecuteRequest {
+public interface WebhookExecuteRequest extends MessageSendRequestBase {
 
     static ImmutableWebhookExecuteRequest.Builder builder() {
         return ImmutableWebhookExecuteRequest.builder();
     }
 
-    Possible<String> content();
     Possible<String> username();
     @JsonProperty("avatar_url")
     Possible<String> avatarUrl();
-    Possible<Boolean> tts();
     Possible<List<EmbedData>> embeds();
-    @JsonProperty("allowed_mentions")
-    Possible<AllowedMentionsData> allowedMentions();
 }

--- a/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
+++ b/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
@@ -1,0 +1,28 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableWebhookExecuteRequest.class)
+@JsonDeserialize(as = ImmutableWebhookExecuteRequest.class)
+public interface WebhookExecuteRequest {
+
+    static ImmutableWebhookExecuteRequest.Builder builder() {
+        return ImmutableWebhookExecuteRequest.builder();
+    }
+
+    Possible<String> content();
+    Possible<String> username();
+    @JsonProperty("avatar_url")
+    Possible<String> avatar_url();
+    Possible<Boolean> tts();
+    Possible<List<EmbedData>> embeds();
+    @JsonProperty("allowed_mentions")
+    Possible<AllowedMentionsData> allowedMentions();
+}

--- a/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
+++ b/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
@@ -20,7 +20,7 @@ public interface WebhookExecuteRequest {
     Possible<String> content();
     Possible<String> username();
     @JsonProperty("avatar_url")
-    Possible<String> avatar_url();
+    Possible<String> avatarUrl();
     Possible<Boolean> tts();
     Possible<List<EmbedData>> embeds();
     @JsonProperty("allowed_mentions")


### PR DESCRIPTION
This is to help implement changes requested for https://github.com/Discord4J/Discord4J/pull/742