### PR TITLE
Added channel follow data and request

### DIFF
--- a/src/main/java/discord4j/discordjson/json/FollowedChannelData.java
+++ b/src/main/java/discord4j/discordjson/json/FollowedChannelData.java
@@ -1,0 +1,22 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableFollowedChannelData.class)
+@JsonDeserialize(as = ImmutableFollowedChannelData.class)
+public interface FollowedChannelData {
+
+    static ImmutableFollowedChannelData.Builder builder() {
+        return ImmutableFollowedChannelData.builder();
+    }
+
+    @JsonProperty("channel_id")
+    String channelId();
+
+    @JsonProperty("webhook_id")
+    String webhookId();
+}

--- a/src/main/java/discord4j/discordjson/json/NewsChannelFollowRequest.java
+++ b/src/main/java/discord4j/discordjson/json/NewsChannelFollowRequest.java
@@ -1,0 +1,19 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableNewsChannelFollowRequest.class)
+@JsonDeserialize(as = ImmutableNewsChannelFollowRequest.class)
+public interface NewsChannelFollowRequest {
+
+    static ImmutableNewsChannelFollowRequest.Builder builder() {
+        return ImmutableNewsChannelFollowRequest.builder();
+    }
+
+    @JsonProperty("webhook_channel_id")
+    String webhookChannelId();
+}


### PR DESCRIPTION
Adds data necessary to implement the /followers endpoint, which allow bots to follow a news channel. Discord documentation is not yet published but a PR has been opened on their side, only a matter of time until it's merged: https://github.com/discord/discord-api-docs/pull/1692/files