### PR TITLE
Add proxy_url field to embed video data

### DIFF
--- a/src/main/java/discord4j/discordjson/json/EmbedVideoData.java
+++ b/src/main/java/discord4j/discordjson/json/EmbedVideoData.java
@@ -1,5 +1,6 @@
 package discord4j.discordjson.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import discord4j.discordjson.possible.Possible;
@@ -15,6 +16,9 @@ public interface EmbedVideoData {
     }
 
     Possible<String> url();
+
+    @JsonProperty("proxy_url")
+    Possible<String> proxyUrl();
 
     Possible<Integer> height();
 


### PR DESCRIPTION
**Justification:** https://github.com/discord/discord-api-docs/pull/2460