### PR TITLE
DM Slash Commands

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandRequest.java
@@ -17,7 +17,7 @@ public interface ApplicationCommandRequest {
     }
 
     /**
-     * 3-32 character command name
+     * 1-32 character name matching ^[\w-]{1,32}$
      */
     String name();
 

--- a/src/main/java/discord4j/discordjson/json/InteractionData.java
+++ b/src/main/java/discord4j/discordjson/json/InteractionData.java
@@ -27,14 +27,17 @@ public interface InteractionData {
 
     /** the guild it was sent from */
     @JsonProperty("guild_id")
-    String guildId();
+    Possible<String> guildId();
 
     /** the channel it was sent from */
     @JsonProperty("channel_id")
-    String channelId();
+    Possible<String> channelId();
 
     /** guild member data for the invoking user */
-    MemberData member();
+    Possible<MemberData> member();
+
+    /** user object for the invoking user, if invoked in a DM */
+    Possible<UserData> user();
 
     /** a continuation token for respoding to the interaction */
     String token();


### PR DESCRIPTION
**Description:** DMs now support commands, meaning `guild_id`, `channel_id` and `member` (replaced by `user`) may be not present. 

**Justification:** 
https://github.com/discord/discord-api-docs/pull/2568
https://github.com/discord/discord-api-docs/pull/2591