### PR TITLE
Removes guild_subscriptions field

### DIFF
--- a/src/main/java/discord4j/discordjson/json/gateway/Identify.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/Identify.java
@@ -16,13 +16,18 @@ public interface Identify extends PayloadData {
     }
 
     String token();
+
     IdentifyProperties properties();
+
     Possible<Boolean> compress();
+
     @JsonProperty("large_threshold")
     int largeThreshold();
+
     Possible<int[]> shard();
+
     Possible<StatusUpdate> presence();
-    @JsonProperty("guild_subscriptions")
-    Possible<Boolean> guildSubscriptions();
+
     Possible<Long> intents();
+
 }

--- a/src/test/java/discord4j/discordjson/json/gateway/GatewaySerializationTest.java
+++ b/src/test/java/discord4j/discordjson/json/gateway/GatewaySerializationTest.java
@@ -86,7 +86,7 @@ public class GatewaySerializationTest {
 
         Identify identify = ImmutableIdentify.of("my_token",
                 ImmutableIdentifyProperties.of("linux", "disco", "disco"),
-                Possible.of(true), 250, Possible.absent(), Possible.absent(), Possible.of(true), Possible.absent());
+                Possible.of(true), 250, Possible.absent(), Possible.absent(), Possible.absent());
         GatewayPayload<Identify> payload = GatewayPayload.identify(identify);
         String result = mapper.writeValueAsString(payload);
 

--- a/src/test/resources/gateway/outbound/Identify.json
+++ b/src/test/resources/gateway/outbound/Identify.json
@@ -8,8 +8,7 @@
       "$device": "disco"
     },
     "compress": true,
-    "large_threshold": 250,
-    "guild_subscriptions": true
+    "large_threshold": 250
   },
   "s":null,
   "t":null


### PR DESCRIPTION
**Description:** When using v8, `intents` are mandatory and they override `guild_subscriptions` no matter its value.

**Justification:** https://github.com/discord/discord-api-docs/pull/2162