### PR TITLE
Updates position modify request

### DIFF
--- a/src/main/java/discord4j/discordjson/json/PositionModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/PositionModifyRequest.java
@@ -1,8 +1,12 @@
 package discord4j.discordjson.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
+
+import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutablePositionModifyRequest.class)
@@ -14,5 +18,13 @@ public interface PositionModifyRequest {
     }
 
     String id();
+
     int position();
+
+    @JsonProperty("lock_permissions")
+    Possible<Optional<Boolean>> lockPermissions();
+
+    @JsonProperty("parent_id")
+    Possible<Optional<String>> parentId();
+
 }


### PR DESCRIPTION
`position` field is marked as `Optional` in the dapi doc but is mandatory in discord-json.
The doc said said `Only channels to be modified are required, with the minimum being a swap between at least two channels.` so it's probably fine.

**Justification:** https://github.com/discord/discord-api-docs/pull/1776