### PR TITLE
Address TODOs

### DIFF
--- a/src/main/java/discord4j/discordjson/json/EmbedProviderData.java
+++ b/src/main/java/discord4j/discordjson/json/EmbedProviderData.java
@@ -18,6 +18,5 @@ public interface EmbedProviderData {
 
     Possible<String> name();
 
-    // TODO [wtf-docs] embed provider can be null
-    Possible<Optional<String>> url();
+    Possible<String> url();
 }

--- a/src/main/java/discord4j/discordjson/json/GuildFields.java
+++ b/src/main/java/discord4j/discordjson/json/GuildFields.java
@@ -69,9 +69,8 @@ public interface GuildFields {
 
     Optional<String> banner();
 
-    // TODO: while https://github.com/discordapp/discord-api-docs/pull/1443 is resolved
     @JsonProperty("premium_subscription_count")
-    Possible<Optional<Integer>> premiumSubscriptionCount();
+    Possible<Integer> premiumSubscriptionCount();
 
     @JsonProperty("public_updates_channel_id")
     Optional<Id> publicUpdatesChannelId();

--- a/src/main/java/discord4j/discordjson/json/GuildUpdateFields.java
+++ b/src/main/java/discord4j/discordjson/json/GuildUpdateFields.java
@@ -27,7 +27,6 @@ public interface GuildUpdateFields extends GuildFields, GuildVerificationLevelFi
     @JsonProperty("premium_tier")
     int premiumTier();
 
-    // TODO: FIX discord docs, as this can be null from GUILD_CREATE
     @JsonProperty("preferred_locale")
-    Optional<String> preferredLocale();
+    String preferredLocale();
 }

--- a/src/test/java/discord4j/discordjson/DataMappingTest.java
+++ b/src/test/java/discord4j/discordjson/DataMappingTest.java
@@ -30,6 +30,7 @@ public class DataMappingTest {
                 .joinedAt(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()))
                 .large(false)
                 .memberCount(1)
+                .preferredLocale("en-US")
                 .build();
         PartialGuildData partialGuildData = PartialGuildData.builder()
                 .from((GuildFields) guildData)


### PR DESCRIPTION
**WARNING**
The first bug will be fixed "soon", the second has not been reported in more than a year and the third was coming from a cache issue on Discord side, it should be fixed by now.
There is nothing that guarantee that these bugs will not come back, it could be a regression.
I just wanted to open this PR to keep track of the TODOs but it might be better to not merge it.

`EmbedProvider#url` being null is fixed
https://github.com/discord/discord-api-docs/issues/2446

`GuildCreate#premium_subscription_count` being null is fixed
https://github.com/discord/discord-api-docs/pull/1443

`GuildUpdate#preferred_locale` being null is fixed