### PR TITLE
Adds Guild#nsfw field

### DIFF
--- a/src/main/java/discord4j/discordjson/json/GuildFields.java
+++ b/src/main/java/discord4j/discordjson/json/GuildFields.java
@@ -86,4 +86,6 @@ public interface GuildFields {
 
     @JsonProperty("welcome_screen")
     Possible<WelcomeScreenData> welcomeScreen();
+
+    Possible<Boolean> nsfw();
 }

--- a/src/test/resources/gateway/GuildCreate.json
+++ b/src/test/resources/gateway/GuildCreate.json
@@ -3,6 +3,7 @@
   "s": 2,
   "op": 0,
   "d": {
+    "nsfw": false,
     "unavailable": false,
     "premium_tier": 0,
     "channels": [

--- a/src/test/resources/gateway/GuildUpdate.json
+++ b/src/test/resources/gateway/GuildUpdate.json
@@ -3,6 +3,7 @@
   "s": 27647,
   "op": 0,
   "d": {
+    "nsfw": false,
     "widget_channel_id": null,
     "system_channel_id": "185949590652977152",
     "premium_tier": 0,

--- a/src/test/resources/rest/Guild.json
+++ b/src/test/resources/rest/Guild.json
@@ -86,5 +86,6 @@
   "system_channel_flags": 1,
   "preferred_locale": "en-US",
   "rules_channel_id": null,
-  "public_updates_channel_id": null
+  "public_updates_channel_id": null,
+  "nsfw": false
 }


### PR DESCRIPTION
This field is not marked as optional but I don't really trust discord to send it every time a guild is sent, especially for partial guild object.

**Justification:** https://github.com/discord/discord-api-docs/pull/2805