### PR TITLE
Make build successful on JDK 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,11 @@ dependencies {
     compileOnly "$immutables_group:builder:$immutables_version"
     annotationProcessor "$immutables_group:value:$immutables_version"
 
+    if (JavaVersion.current().isJava8()) {
+        compileOnly "com.google.code.findbugs:annotations:3.0.1"
+        testCompileOnly "com.google.code.findbugs:annotations:3.0.1"
+    }
+
     testCompileOnly project(':encoding')
     testCompileOnly "$immutables_group:value:$immutables_version"
     testAnnotationProcessor "$immutables_group:value:$immutables_version"

--- a/encoding/build.gradle
+++ b/encoding/build.gradle
@@ -3,4 +3,9 @@ dependencies {
     compileOnly "$immutables_group:value:$immutables_version"
     annotationProcessor "$immutables_group:value:$immutables_version"
     api "$immutables_group:encode:$immutables_version"
+
+    if (JavaVersion.current().isJava8()) {
+        compileOnly "com.google.code.findbugs:annotations:3.0.1"
+        testCompileOnly "com.google.code.findbugs:annotations:3.0.1"
+    }
 }


### PR DESCRIPTION
The cause was that `javax.annotation.meta.TypeQualifierNickname` was missing on the classpath. For JDK 8 it requires an extra dependency, `com.google.code.findbugs:annotations:3.0.1`.

I would have never found out if I wasn't working on immutable specs on the main repo...

https://stackoverflow.com/questions/11104667/java-compilation-error-using-findbugs-com-sun-tools-javac-code-symbolcompletio