### PR TITLE
Member#joinedAt is nullable

### DIFF
--- a/src/main/java/discord4j/discordjson/json/MemberData.java
+++ b/src/main/java/discord4j/discordjson/json/MemberData.java
@@ -25,8 +25,9 @@ public interface MemberData {
 
     List<Id> roles();
 
+    // Nullable for member update event concerning lurker in stage channel
     @JsonProperty("joined_at")
-    String joinedAt();
+    Optional<String> joinedAt();
 
     @JsonProperty("premium_since")
     Possible<Optional<String>> premiumSince();


### PR DESCRIPTION
`MemberUpdateEvent` creates a member object. Now that this field is optional for the event, it also needs to be optional for member object. The alternative could be to create another interface with only the `joined_at` field.

**Justification:** 
https://github.com/discord/discord-api-docs/pull/2911#issuecomment-841390008
https://github.com/Discord4J/discord-json/pull/83