### PR TITLE
Assign default value to Possible encodings

### DIFF
--- a/encoding/src/main/java/discord4j/discordjson/OptionalIdEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/OptionalIdEncoding.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public class OptionalIdEncoding {
 
     @Encoding.Impl(virtual = true)
-    private Optional<Id> optional;
+    private Optional<Id> optional = Optional.empty();
 
     private final long value = optional
             .map(discord4j.discordjson.Id::asLong)

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleEncoding.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 public class PossibleEncoding<T> {
 
     @Encoding.Impl(virtual = true)
-    private Possible<T> possible;
+    private Possible<T> possible = discord4j.discordjson.possible.Possible.absent();
 
     private final T value = possible.toOptional().orElse(null);
     private final boolean absent = possible.isAbsent();

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleIdEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleIdEncoding.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public class PossibleIdEncoding {
 
     @Encoding.Impl(virtual = true)
-    private Possible<Id> possible;
+    private Possible<Id> possible = discord4j.discordjson.possible.Possible.absent();
 
     private final long value = possible.toOptional()
             .map(discord4j.discordjson.Id::asLong)

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleIntArrayEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleIntArrayEncoding.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 public class PossibleIntArrayEncoding {
 
     @Encoding.Impl(virtual = true)
-    private Possible<int[]> possible;
+    private Possible<int[]> possible = discord4j.discordjson.possible.Possible.absent();
 
     private final int[] value = possible.toOptional().orElse(null);
     private final boolean absent = possible.isAbsent();

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleListEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleListEncoding.java
@@ -12,7 +12,7 @@ import java.util.stream.StreamSupport;
 public class PossibleListEncoding<T> {
 
     @Encoding.Impl(virtual = true)
-    private Possible<List<T>> possible;
+    private Possible<List<T>> possible = discord4j.discordjson.possible.Possible.absent();
 
     private final List<T> value = possible.toOptional().orElse(null);
     private final boolean absent = possible.isAbsent();

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalEncoding.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public class PossibleOptionalEncoding<T> {
 
     @Encoding.Impl(virtual = true)
-    private Possible<Optional<T>> possible;
+    private Possible<Optional<T>> possible = discord4j.discordjson.possible.Possible.absent();
 
     private final T value = discord4j.discordjson.possible.Possible.flatOpt(possible).orElse(null);
     private final boolean absent = possible.isAbsent();

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalIdEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalIdEncoding.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public class PossibleOptionalIdEncoding {
 
     @Encoding.Impl(virtual = true)
-    private Possible<Optional<Id>> possible;
+    private Possible<Optional<Id>> possible = discord4j.discordjson.possible.Possible.absent();
 
     private final long value = discord4j.discordjson.possible.Possible.flatOpt(possible)
             .map(discord4j.discordjson.Id::asLong)


### PR DESCRIPTION
# Description

Properly assign `Possible.absent()` as default value in encoding module (it currently only does for the Builder, but not for static constructors)

# Justification

Currently the following code fails to compile:
```java
@Value.Immutable(singleton = true)
interface MemberEditSpecGenerator {

    Possible<Optional<String>> nickname();
}
```
Result:
```
error: Could not generate constructor for MemberEditSpec. Attribute 'nickname' does not have default value
```