### PR TITLE
Reintroduce #93 but deprecate old overloads

### DIFF
--- a/encoding/src/main/java/discord4j/discordjson/MetaEncodingEnabled.java
+++ b/encoding/src/main/java/discord4j/discordjson/MetaEncodingEnabled.java
@@ -6,6 +6,7 @@ import discord4j.discordjson.possible.*;
 @ListIdEncodingEnabled
 @OptionalIdEncodingEnabled
 @PossibleListEncodingEnabled
+@PossibleOptionalListEncodingEnabled
 @PossibleOptionalIdEncodingEnabled
 @PossibleOptionalEncodingEnabled
 @PossibleIdEncodingEnabled

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleListEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleListEncoding.java
@@ -3,6 +3,7 @@ package discord4j.discordjson.possible;
 import org.immutables.encode.Encoding;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -31,6 +32,23 @@ public class PossibleListEncoding<T> {
     @Encoding.Naming("*OrElse")
     List<T> orElse(List<T> defaultValue) {
         return !absent ? value : defaultValue;
+    }
+
+    @Encoding.Copy
+    public Possible<List<T>> withPossible(Possible<List<T>> possible) {
+        return Objects.requireNonNull(possible);
+    }
+
+    @Encoding.Copy
+    public Possible<List<T>> withIterable(Iterable<T> elements) {
+        return discord4j.discordjson.possible.Possible.of(
+                StreamSupport.stream(Objects.requireNonNull(elements).spliterator(), false).collect(Collectors.toList()));
+    }
+
+    @Encoding.Copy
+    @SafeVarargs
+    public final Possible<List<T>> withVarargs(T... elements) {
+        return discord4j.discordjson.possible.Possible.of(Arrays.asList(elements));
     }
 
     //    @Encoding.Of

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalEncoding.java
@@ -37,7 +37,14 @@ public class PossibleOptionalEncoding<T> {
     }
 
     @Encoding.Copy
+    @Deprecated
     public Possible<Optional<T>> with(final @Nullable T value) {
+        return discord4j.discordjson.possible.Possible.of(Optional.ofNullable(value));
+    }
+
+    @Encoding.Naming("with*OrNull")
+    @Encoding.Copy
+    public Possible<Optional<T>> withOrNull(final @Nullable T value) {
         return discord4j.discordjson.possible.Possible.of(Optional.ofNullable(value));
     }
 
@@ -53,7 +60,14 @@ public class PossibleOptionalEncoding<T> {
         }
 
         @Encoding.Init
+        @Deprecated
         public void setValue(@Nullable T value) {
+            this.possible = discord4j.discordjson.possible.Possible.of(Optional.ofNullable(value));
+        }
+
+        @Encoding.Naming("*OrNull")
+        @Encoding.Init
+        public void setValueOrNull(@Nullable T value) {
             this.possible = discord4j.discordjson.possible.Possible.of(Optional.ofNullable(value));
         }
 

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalIdEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalIdEncoding.java
@@ -40,7 +40,15 @@ public class PossibleOptionalIdEncoding {
     }
 
     @Encoding.Copy
+    @Deprecated
     public Possible<Optional<Id>> with(final @Nullable Long value) {
+        return value == null ? discord4j.discordjson.possible.Possible.of(Optional.empty()) :
+                discord4j.discordjson.possible.Possible.of(Optional.of(discord4j.discordjson.Id.of(value)));
+    }
+
+    @Encoding.Naming("with*OrNull")
+    @Encoding.Copy
+    public Possible<Optional<Id>> withOrNull(final @Nullable Long value) {
         return value == null ? discord4j.discordjson.possible.Possible.of(Optional.empty()) :
                 discord4j.discordjson.possible.Possible.of(Optional.of(discord4j.discordjson.Id.of(value)));
     }

--- a/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalListEncoding.java
+++ b/encoding/src/main/java/discord4j/discordjson/possible/PossibleOptionalListEncoding.java
@@ -1,0 +1,152 @@
+package discord4j.discordjson.possible;
+
+import org.immutables.encode.Encoding;
+import reactor.util.annotation.Nullable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@Encoding
+public class PossibleOptionalListEncoding<T> {
+
+    @Encoding.Impl(virtual = true)
+    private Possible<Optional<List<T>>> possible = discord4j.discordjson.possible.Possible.absent();
+
+    private final List<T> value = discord4j.discordjson.possible.Possible.flatOpt(possible).orElse(null);
+    private final boolean absent = possible.isAbsent();
+
+    @Encoding.Expose
+    Possible<Optional<List<T>>> get() {
+        return absent ? discord4j.discordjson.possible.Possible.absent() :
+                discord4j.discordjson.possible.Possible.of(Optional.ofNullable(value));
+    }
+
+    @Encoding.Naming("is*Present")
+    boolean isPresent() {
+        return !absent;
+    }
+
+    @Encoding.Naming("*OrElse")
+    List<T> orElse(List<T> defaultValue) {
+        return !absent ? value : defaultValue;
+    }
+
+    @Encoding.Copy
+    public Possible<Optional<List<T>>> withPossible(Possible<Optional<List<T>>> possible) {
+        return Objects.requireNonNull(possible);
+    }
+
+    @Encoding.Copy
+    @Deprecated
+    public Possible<Optional<List<T>>> withIterable(@Nullable Iterable<T> elements) {
+        return discord4j.discordjson.possible.Possible.of(Optional.ofNullable(elements)
+                .map(els -> StreamSupport.stream(els.spliterator(), false).collect(Collectors.toList())));
+    }
+
+    @Encoding.Naming("with*OrNull")
+    @Encoding.Copy
+    public Possible<Optional<List<T>>> withIterableOrNull(@Nullable Iterable<T> elements) {
+        return discord4j.discordjson.possible.Possible.of(Optional.ofNullable(elements)
+                .map(els -> StreamSupport.stream(els.spliterator(), false).collect(Collectors.toList())));
+    }
+
+    @Encoding.Copy
+    @SafeVarargs
+    public final Possible<Optional<List<T>>> withVarargs(T... elements) {
+        return discord4j.discordjson.possible.Possible.of(Optional.of(Arrays.asList(elements)));
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toString(value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    public boolean equals(PossibleOptionalListEncoding<T> obj) {
+        return Objects.equals(value, obj.value);
+    }
+
+    @Encoding.Builder
+    static class Builder<T> {
+
+        private List<T> list = null;
+        private boolean explicitNull;
+
+        @Encoding.Naming(standard = Encoding.StandardNaming.ADD)
+        @Encoding.Init
+        void add(T element) {
+            getOrCreate().add(element);
+            this.explicitNull = false;
+        }
+
+        @Encoding.Naming(standard = Encoding.StandardNaming.ADD_ALL)
+        @Encoding.Init
+        void addAll(List<T> elements) {
+            getOrCreate().addAll(elements);
+            this.explicitNull = false;
+        }
+
+        @Encoding.Build
+        Possible<Optional<List<T>>> build() {
+            return this.list == null && !explicitNull ? discord4j.discordjson.possible.Possible.absent() :
+                    discord4j.discordjson.possible.Possible.of(Optional.ofNullable(this.list));
+        }
+
+        @Encoding.Init
+        @Encoding.Copy
+        void set(Possible<Optional<List<T>>> elements) {
+            this.list = null;
+            this.explicitNull = false;
+
+            elements.toOptional().ifPresent(e -> {
+                if (e.isPresent()) {
+                    getOrCreate().addAll(e.get());
+                } else {
+                    this.explicitNull = true;
+                }
+            });
+        }
+
+        @Encoding.Init
+        void setValue(List<T> elements) {
+            this.list = new ArrayList<>(elements);
+            this.explicitNull = false;
+        }
+
+        @Encoding.Init
+        @Deprecated
+        void setValueIterable(@Nullable Iterable<T> elements) {
+            if (elements == null) {
+                this.list = null;
+                this.explicitNull = true;
+            } else {
+                this.list = StreamSupport.stream(elements.spliterator(), false).collect(Collectors.toList());
+                this.explicitNull = false;
+            }
+        }
+
+        @Encoding.Naming("*OrNull")
+        @Encoding.Init
+        void setValueIterableOrNull(@Nullable Iterable<T> elements) {
+            if (elements == null) {
+                this.list = null;
+                this.explicitNull = true;
+            } else {
+                this.list = StreamSupport.stream(elements.spliterator(), false).collect(Collectors.toList());
+                this.explicitNull = false;
+            }
+        }
+
+        private List<T> getOrCreate() {
+            if (this.list == null) {
+                this.list = new ArrayList<>();
+            }
+            return this.list;
+        }
+    }
+}

--- a/src/test/java/discord4j/discordjson/PossibleDeserializerTest.java
+++ b/src/test/java/discord4j/discordjson/PossibleDeserializerTest.java
@@ -60,7 +60,7 @@ public class PossibleDeserializerTest {
     public void testPossibleOptionalEncoding() {
         Foo foo = ImmutableFoo.builder()
                 .addList("element")
-                .optional("present")
+                .optionalOrNull("present")
                 .possible("possible")
                 .build();
         assertFalse(foo.list().isAbsent());


### PR DESCRIPTION
This should prevent other branches of Discord4J from failing to build.