### PR TITLE
Changed type of ApplicationCommandOptionChoiceData#value from String to Object

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionChoiceData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionChoiceData.java
@@ -19,7 +19,9 @@ public interface ApplicationCommandOptionChoiceData {
     String name();
 
     /**
-     * value of the choice
+     * value of the choice, should be either a String or an Integer.
+     *
+     * @see <a href="https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice">ApplicationCommandOptionChoice</a>
      */
-    String value();
+    Object value();
 }


### PR DESCRIPTION
Discord wants an integer type if the ApplicationCommandOptionType is INTEGER. See: [ApplicationCommandOptionChoice](https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice)

Currently, when posting a command with an integer option + choices, the values are serialized as strings, which causes the API to reject the call with a 400 Bad Request.