### PR TITLE
Add support for multiple embeds in a message

### DIFF
--- a/src/main/java/discord4j/discordjson/json/MessageCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/MessageCreateRequest.java
@@ -14,5 +14,6 @@ public interface MessageCreateRequest extends MessageSendRequestBase {
     }
 
     Possible<Object> nonce();
+    @Deprecated
     Possible<EmbedData> embed();
 }

--- a/src/main/java/discord4j/discordjson/json/MessageEditRequest.java
+++ b/src/main/java/discord4j/discordjson/json/MessageEditRequest.java
@@ -20,7 +20,10 @@ public interface MessageEditRequest {
 
     Possible<Optional<String>> content();
 
+    @Deprecated
     Possible<Optional<EmbedData>> embed();
+
+    Possible<Optional<List<EmbedData>>> embeds();
 
     Possible<Optional<Integer>> flags();
 

--- a/src/main/java/discord4j/discordjson/json/MessageSendRequestBase.java
+++ b/src/main/java/discord4j/discordjson/json/MessageSendRequestBase.java
@@ -18,4 +18,6 @@ public interface MessageSendRequestBase {
     Possible<MessageReferenceData> messageReference();
 
     Possible<List<ComponentData>> components();
+
+    Possible<List<EmbedData>> embeds();
 }

--- a/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
+++ b/src/main/java/discord4j/discordjson/json/WebhookExecuteRequest.java
@@ -20,5 +20,4 @@ public interface WebhookExecuteRequest extends MessageSendRequestBase {
     Possible<String> username();
     @JsonProperty("avatar_url")
     Possible<String> avatarUrl();
-    Possible<List<EmbedData>> embeds();
 }


### PR DESCRIPTION
See https://github.com/discord/discord-api-docs/pull/3105

I deprecated `MessageCreateRequest#embed()`, but it seems like that doesn't get forwarded to most of the generated methods, so I'm not sure if it's even worth doing (unless we really want to maintain compatibility). 