### PR TITLE
Documentation complementing Discord4J#971

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandData.java
@@ -29,7 +29,7 @@ public interface ApplicationCommandData {
     String applicationId();
 
     /**
-     * 3-32 character name
+     * 1-32 character name
      */
     String name();
 

--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionChoiceData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionChoiceData.java
@@ -19,7 +19,9 @@ public interface ApplicationCommandOptionChoiceData {
     String name();
 
     /**
-     * value of the choice, should be either a String or an Integer.
+     * value of the choice, should be either an up to 100 character {@link String} for ApplicationCommandOptionType.STRING,
+     * a {@link Byte}/{@link Short}/{@link Integer}/{@link Long} for ApplicationCommandOptionType.INTEGER
+     * or a {@link Float}/{@link Double} for ApplicationCommandOptionType.NUMBER.
      *
      * @see <a href="https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice">ApplicationCommandOptionChoice</a>
      */

--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionData.java
@@ -36,7 +36,7 @@ public interface ApplicationCommandOptionData {
      */
     Possible<Boolean> required();
 
-    /** choices for string and int types for the user to pick from */
+    /** choices for STRING, INTEGER, and NUMBER Application Command Option Types for the user to pick from */
     Possible<List<ApplicationCommandOptionChoiceData>> choices();
 
     /**


### PR DESCRIPTION
**Description:**
* Changes documentation for `ApplicationCommandOptionChoiceData#value()` and `ApplicationCommandOptionData#choices()` to complement https://github.com/Discord4J/Discord4J/pull/971.
* Fixes wrong length of name in documentation for `ApplicationCommandData#name()`.

**Justification:**
* https://github.com/Discord4J/Discord4J/pull/971
* https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-structure (see description for field `name`)