### PR TITLE
Make MemberData extends PartialMemberData

### DIFF
--- a/src/main/java/discord4j/discordjson/json/MemberData.java
+++ b/src/main/java/discord4j/discordjson/json/MemberData.java
@@ -1,19 +1,14 @@
 package discord4j.discordjson.json;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import discord4j.discordjson.Id;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
-
-import java.util.List;
-import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableMemberData.class)
 @JsonDeserialize(as = ImmutableMemberData.class)
-public interface MemberData {
+public interface MemberData extends PartialMemberData {
 
     static ImmutableMemberData.Builder builder() {
         return ImmutableMemberData.builder();
@@ -21,27 +16,8 @@ public interface MemberData {
 
     UserData user();
 
-    Possible<Optional<String>> nick();
-
-    List<Id> roles();
-
-    // Nullable for member update event concerning lurker in stage channel
-    @JsonProperty("joined_at")
-    Optional<String> joinedAt();
-
-    @JsonProperty("premium_since")
-    Possible<Optional<String>> premiumSince();
-
-    @JsonProperty("hoisted_role")
-    Optional<String> hoistedRole();
-
-    boolean deaf();
-
-    boolean mute();
-
     Possible<Boolean> pending();
 
     /** total permissions of the member in the channel, including overrides, returned when in the interaction object. */
     Possible<String> permissions();
-
 }

--- a/src/main/java/discord4j/discordjson/json/PartialMemberData.java
+++ b/src/main/java/discord4j/discordjson/json/PartialMemberData.java
@@ -23,8 +23,9 @@ public interface PartialMemberData {
 
     List<Id> roles();
 
+    // Nullable for member update event concerning lurker in stage channel
     @JsonProperty("joined_at")
-    String joinedAt();
+    Optional<String> joinedAt();
 
     @JsonProperty("premium_since")
     Possible<Optional<String>> premiumSince();


### PR DESCRIPTION
**Description:**
Changes the hierarchy `MemberData` making it extending `PartialMemberData`.

Required for https://github.com/Discord4J/Discord4J/pull/982
