### PR TITLE
Add support for context menu commands

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandData.java
@@ -23,6 +23,11 @@ public interface ApplicationCommandData {
     String id();
 
     /**
+     *  value of ApplicationCommandType (defaults to 1, CHAT_INPUT)
+     */
+    Possible<Integer> type();
+
+    /**
      * unique id of the parent application
      */
     @JsonProperty("application_id")
@@ -34,7 +39,7 @@ public interface ApplicationCommandData {
     String name();
 
     /**
-     * 1-100 character description
+     * 0-100 character description
      */
     String description();
 

--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandRequest.java
@@ -18,14 +18,15 @@ public interface ApplicationCommandRequest {
     }
 
     /**
-     * 1-32 character name matching ^[\w-]{1,32}$
+     * 1-32 character name matching ^[\w-]{1,32}$ for CHAT_INPUT.
+     * USER and MESSAGE commands may be mixed case with spaces
      */
     String name();
 
     /**
-     * 1-100 character description
+     * 1-100 character description. Not allowed for USER and MESSAGE command types
      */
-    String description();
+    Possible<String> description();
 
     /**
      * the parameters for the command
@@ -34,4 +35,9 @@ public interface ApplicationCommandRequest {
 
     @JsonProperty("default_permission")
     Possible<Boolean> defaultPermission();
+
+    /**
+     * value of ApplicationCommandType (defaults to 1, CHAT_INPUT)
+     */
+    Possible<Integer> type();
 }

--- a/src/main/java/discord4j/discordjson/json/InteractionData.java
+++ b/src/main/java/discord4j/discordjson/json/InteractionData.java
@@ -49,5 +49,6 @@ public interface InteractionData {
     /** read-only property, always 1 */
     int version();
 
+    /** message associated with the interaction. */
     Possible<MessageData> message();
 }


### PR DESCRIPTION
This adds support for the new context menu commands (USER and MESSAGE types)

### Added
* `type` field of `Possible<Integer>` to `ApplicationCommandData`
* `type` field of `Possible<Integer>` to `ApplicationCommandRequest`

### Changed
* `description` field changed to `Possible<String>` in `ApplicationCommandRequest`
  * Justification: Field not allowed when creating USER or MESSAGE type commands.
  * This field returns an empty string when fetching commands so type-change is not needed in its data counterpart.
*  `message` field changed to `Possible<MessageData>` in `InteractionData`
    * Justification: Discord no longer returns partial data for interactions on ephemeral messages.
* Documentation on `description` and `name` fields in changed classes
  * Justification: Discord only applies the regex to CHAT_INPUT type commands, MESSAGE and USER types are only bound by the character count limit.
  
### Justification & Related Issues/PRs
* https://github.com/discord/discord-api-docs/pull/3614
* https://github.com/Discord4J/Discord4J/issues/983
* https://github.com/Discord4J/Discord4J/pull/996