### PR TITLE
Add support for min/max value fields on number-based options

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationCommandOptionData.java
@@ -52,4 +52,20 @@ public interface ApplicationCommandOptionData {
      */
     @JsonProperty("channel_types")
     Possible<List<Integer>> channelTypes();
+
+    /**
+     * The minimum value allowed to be entered. Only valid for INTEGER and NUMBER type options.
+     * </p>
+     * If not provided, no restriction is placed on the minimum value permitted.
+     */
+    @JsonProperty("min_value")
+    Possible<Number> minValue();
+
+    /**
+     * The maximum value allowed to be entered. Only valid for INTEGER and NUMBER type options.
+     * </p>
+     * If not provided, no restriction is placed on the maximum value permitted.
+     */
+    @JsonProperty("max_value")
+    Possible<Number> maxValue();
 }


### PR DESCRIPTION
new `min_value?` and `max_value?` fields for application command options of type NUMBER or INTEGER

See discord/discord-api-docs#3967

Waiting for dapi PR merge before this is merged.