### PR TITLE
Add support for Guild Scheduled Events

### DIFF
--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
@@ -9,7 +9,6 @@ import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.time.Instant;
-import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableGuildScheduledEventCreateRequest.class)
@@ -20,9 +19,9 @@ public interface GuildScheduledEventCreateRequest {
         return ImmutableGuildScheduledEventCreateRequest.builder();
     }
 
-    /* should be null for events with `entity_type: EXTERNAL` */
+    /* Possible for events with entity type external */
     @JsonProperty("channel_id")
-    Optional<Id> channelId();
+    Possible<Id> channelId();
 
     @JsonProperty("entity_metadata")
     Possible<GuildScheduledEventEntityMetadataData> entityMetadata();

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
@@ -1,0 +1,42 @@
+package discord4j.discordjson.json;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.time.Instant;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventCreateRequest.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventCreateRequest.class)
+public interface GuildScheduledEventCreateRequest {
+
+    static ImmutableGuildScheduledEventCreateRequest.Builder builder() {
+        return ImmutableGuildScheduledEventCreateRequest.builder();
+    }
+
+    @JsonProperty("channel_id")
+    Possible<Id> channelId();
+
+    @JsonProperty("entity_metadata")
+    Possible<GuildScheduledEventEntityMetadataData> entityMetadata();
+
+    String name();
+
+    @JsonProperty("privacy_level")
+    int privacyLevel();
+
+    @JsonProperty("scheduled_start_time")
+    Instant scheduledStartTime();
+
+    @JsonProperty("scheduled_end_time")
+    Possible<Instant> scheduledEndTime();
+
+    Possible<String> description();
+
+    int entityType();
+}

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
@@ -9,6 +9,7 @@ import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.time.Instant;
+import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableGuildScheduledEventCreateRequest.class)
@@ -19,8 +20,9 @@ public interface GuildScheduledEventCreateRequest {
         return ImmutableGuildScheduledEventCreateRequest.builder();
     }
 
+    /* should be null for events with `entity_type: EXTERNAL` */
     @JsonProperty("channel_id")
-    Possible<Id> channelId();
+    Optional<Id> channelId();
 
     @JsonProperty("entity_metadata")
     Possible<GuildScheduledEventEntityMetadataData> entityMetadata();

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventData.java
@@ -1,0 +1,61 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventData.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventData.class)
+public interface GuildScheduledEventData {
+
+    static ImmutableGuildScheduledEventData.Builder builder() {
+        return ImmutableGuildScheduledEventData.builder();
+    }
+
+    Id id();
+
+    @JsonProperty("guild_id")
+    Id guildId();
+
+    @JsonProperty("channel_id")
+    Optional<Id> channelId();
+
+    @JsonProperty("creator_id")
+    Possible<Id> creatorId();
+
+    String name();
+
+    Possible<String> description();
+
+    @JsonProperty("scheduled_start_time")
+    Instant scheduledStartTime();
+
+    @JsonProperty("scheduled_end_time")
+    Optional<Instant> scheduledEndTime();
+
+    @JsonProperty("privacy_level")
+    int privacyLevel();
+
+    int status();
+
+    @JsonProperty("entity_type")
+    int entityType();
+
+    @JsonProperty("entity_id")
+    Optional<Id> entityId();
+
+    @JsonProperty("entity_metadata")
+    Optional<GuildScheduledEventEntityMetadataData> entityMetadata();
+
+    Possible<UserData> creator();
+
+    @JsonProperty("user_count")
+    Possible<Integer> userCount();
+}

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventData.java
@@ -25,6 +25,7 @@ public interface GuildScheduledEventData {
     @JsonProperty("guild_id")
     Id guildId();
 
+    /* Special rules apply to when this is present see https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-field-requirements-by-entity-type */
     @JsonProperty("channel_id")
     Optional<Id> channelId();
 
@@ -39,6 +40,7 @@ public interface GuildScheduledEventData {
     @JsonProperty("scheduled_start_time")
     Instant scheduledStartTime();
 
+    /* Required if entity type is external */
     @JsonProperty("scheduled_end_time")
     Optional<Instant> scheduledEndTime();
 

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventData.java
@@ -7,6 +7,7 @@ import discord4j.discordjson.Id;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
+import javax.swing.text.html.Option;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -27,8 +28,9 @@ public interface GuildScheduledEventData {
     @JsonProperty("channel_id")
     Optional<Id> channelId();
 
+    /* creator ID will be null and creator will not be included for events created before oct 25th 2021 */
     @JsonProperty("creator_id")
-    Possible<Id> creatorId();
+    Optional<Id> creatorId();
 
     String name();
 

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventEntityMetadataData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventEntityMetadataData.java
@@ -1,0 +1,25 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventEntityMetadataData.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventEntityMetadataData.class)
+public interface GuildScheduledEventEntityMetadataData {
+
+    static ImmutableGuildScheduledEventEntityMetadataData.Builder builder() {
+        return ImmutableGuildScheduledEventEntityMetadataData.builder();
+    }
+
+    @JsonProperty("speaker_ids")
+    Possible<List<Id>> speakerIds();
+
+    Possible<String> location();
+}

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventEntityMetadataData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventEntityMetadataData.java
@@ -1,13 +1,9 @@
 package discord4j.discordjson.json;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import discord4j.discordjson.Id;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
-
-import java.util.List;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableGuildScheduledEventEntityMetadataData.class)
@@ -17,9 +13,6 @@ public interface GuildScheduledEventEntityMetadataData {
     static ImmutableGuildScheduledEventEntityMetadataData.Builder builder() {
         return ImmutableGuildScheduledEventEntityMetadataData.builder();
     }
-
-    @JsonProperty("speaker_ids")
-    Possible<List<Id>> speakerIds();
 
     Possible<String> location();
 }

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventEntityMetadataData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventEntityMetadataData.java
@@ -14,5 +14,6 @@ public interface GuildScheduledEventEntityMetadataData {
         return ImmutableGuildScheduledEventEntityMetadataData.builder();
     }
 
+    /* Required for events with entity type external */
     Possible<String> location();
 }

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventModifyRequest.java
@@ -1,0 +1,45 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.time.Instant;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventModifyRequest.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventModifyRequest.class)
+public interface GuildScheduledEventModifyRequest {
+
+    static ImmutableGuildScheduledEventModifyRequest.Builder builder() {
+        return ImmutableGuildScheduledEventModifyRequest.builder();
+    }
+
+    /* Required if entity type is STAGE or VOICE channel */
+    @JsonProperty("channel_id")
+    Possible<Id> channelId();
+
+    @JsonProperty("entity_metadata")
+    Possible<GuildScheduledEventEntityMetadataData> entityMetadata();
+
+    Possible<String> name();
+
+    @JsonProperty("privacy_level")
+    Possible<Integer> privacyLevel();
+
+    @JsonProperty("scheduled_start_time")
+    Possible<Instant> scheduledStartTime();
+
+    @JsonProperty("scheduled_end_time")
+    Possible<Instant> scheduledEndTime();
+
+    Possible<String> description();
+
+    @JsonProperty("entity_type")
+    Possible<Integer> entityType();
+
+    Possible<Integer> status();
+}

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventModifyRequest.java
@@ -19,10 +19,11 @@ public interface GuildScheduledEventModifyRequest {
         return ImmutableGuildScheduledEventModifyRequest.builder();
     }
 
-    /* Required if entity type is STAGE or VOICE channel */
+    /* must be set to null if entity type is changed to external */
     @JsonProperty("channel_id")
     Possible<Optional<Id>> channelId();
 
+    /* Required (with location) if changing entity type to external */
     @JsonProperty("entity_metadata")
     Possible<GuildScheduledEventEntityMetadataData> entityMetadata();
 
@@ -34,6 +35,7 @@ public interface GuildScheduledEventModifyRequest {
     @JsonProperty("scheduled_start_time")
     Possible<Instant> scheduledStartTime();
 
+    /* Required if changing entity type to external */
     @JsonProperty("scheduled_end_time")
     Possible<Instant> scheduledEndTime();
 

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventModifyRequest.java
@@ -8,6 +8,7 @@ import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.time.Instant;
+import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableGuildScheduledEventModifyRequest.class)
@@ -20,7 +21,7 @@ public interface GuildScheduledEventModifyRequest {
 
     /* Required if entity type is STAGE or VOICE channel */
     @JsonProperty("channel_id")
-    Possible<Id> channelId();
+    Possible<Optional<Id>> channelId();
 
     @JsonProperty("entity_metadata")
     Possible<GuildScheduledEventEntityMetadataData> entityMetadata();

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventUserData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventUserData.java
@@ -1,0 +1,27 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventUserData.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventUserData.class)
+public interface GuildScheduledEventUserData {
+
+    static ImmutableGuildScheduledEventUserData.Builder builder() {
+        return ImmutableGuildScheduledEventUserData.builder();
+    }
+
+    @JsonProperty("guild_scheduled_event_id")
+    Id guildScheduledEventId();
+
+    UserData user();
+
+    @JsonProperty("guild_member")
+    Possible<PartialMemberData> guildMember();
+}
+

--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventUserData.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventUserData.java
@@ -21,7 +21,6 @@ public interface GuildScheduledEventUserData {
 
     UserData user();
 
-    @JsonProperty("guild_member")
-    Possible<PartialMemberData> guildMember();
+    Possible<PartialMemberData> member();
 }
 

--- a/src/main/java/discord4j/discordjson/json/InviteData.java
+++ b/src/main/java/discord4j/discordjson/json/InviteData.java
@@ -45,6 +45,9 @@ public interface InviteData {
     @JsonProperty("expires_at")
     Possible<Optional<String>> expiresAt();
 
+    @JsonProperty("guild_scheduled_event")
+    Possible<GuildScheduledEventData> guildScheduledEvent();
+
     Possible<Integer> uses();
 
     @JsonProperty("max_uses")

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventCreate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventCreate.java
@@ -1,0 +1,20 @@
+package discord4j.discordjson.json.gateway;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.GuildScheduledEventData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventCreate.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventCreate.class)
+public interface GuildScheduledEventCreate extends Dispatch {
+
+    static ImmutableGuildScheduledEventCreate.Builder builder() {
+        return ImmutableGuildScheduledEventCreate.builder();
+    }
+
+    @JsonUnwrapped
+    GuildScheduledEventData scheduledEvent();
+}

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventDelete.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventDelete.java
@@ -1,0 +1,20 @@
+package discord4j.discordjson.json.gateway;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.GuildScheduledEventData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventDelete.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventDelete.class)
+public interface GuildScheduledEventDelete extends Dispatch {
+
+    static ImmutableGuildScheduledEventDelete.Builder builder() {
+        return ImmutableGuildScheduledEventDelete.builder();
+    }
+
+    @JsonUnwrapped
+    GuildScheduledEventData scheduledEvent();
+}

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventUpdate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventUpdate.java
@@ -1,0 +1,20 @@
+package discord4j.discordjson.json.gateway;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.GuildScheduledEventData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventUpdate.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventUpdate.class)
+public interface GuildScheduledEventUpdate extends Dispatch {
+
+    static ImmutableGuildScheduledEventUpdate.Builder builder() {
+        return ImmutableGuildScheduledEventUpdate.builder();
+    }
+
+    @JsonUnwrapped
+    GuildScheduledEventData scheduledEvent();
+}

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventUserAdd.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventUserAdd.java
@@ -1,0 +1,30 @@
+package discord4j.discordjson.json.gateway;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import org.immutables.value.Value;
+
+/**
+ * Note: This event is considered experimental by Discord.
+ * https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-add
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventUserAdd.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventUserAdd.class)
+public interface GuildScheduledEventUserAdd extends Dispatch {
+
+    static ImmutableGuildScheduledEventUserAdd.Builder builder() {
+        return ImmutableGuildScheduledEventUserAdd.builder();
+    }
+
+    @JsonProperty("guild_scheduled_event_id")
+    Id scheduledEventId();
+
+    @JsonProperty("user_id")
+    Id userId();
+
+    @JsonProperty("guild_id")
+    Id guildId();
+}

--- a/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventUserRemove.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/GuildScheduledEventUserRemove.java
@@ -1,0 +1,30 @@
+package discord4j.discordjson.json.gateway;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import org.immutables.value.Value;
+
+/**
+ * Note: This event is considered experimental by Discord.
+ * https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-remove
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableGuildScheduledEventUserRemove.class)
+@JsonDeserialize(as = ImmutableGuildScheduledEventUserRemove.class)
+public interface GuildScheduledEventUserRemove extends Dispatch {
+
+    static ImmutableGuildScheduledEventUserRemove.Builder builder() {
+        return ImmutableGuildScheduledEventUserRemove.builder();
+    }
+
+    @JsonProperty("guild_scheduled_event_id")
+    Id scheduledEventId();
+
+    @JsonProperty("user_id")
+    Id userId();
+
+    @JsonProperty("guild_id")
+    Id guildId();
+}


### PR DESCRIPTION
This PR adds support for the new Guild Scheduled Events resource

Also adds `Possible<GuildScheduledEventData>` to `InviteData` for invites generated for guild events

# Justification
* https://discord.com/developers/docs/resources/guild-scheduled-event
* https://github.com/discord/discord-api-docs/pull/3586
* https://github.com/discord/discord-api-docs/pull/4113