### PR TITLE
Make enabled field optional for IntegrationData

### DIFF
--- a/src/main/java/discord4j/discordjson/json/IntegrationData.java
+++ b/src/main/java/discord4j/discordjson/json/IntegrationData.java
@@ -22,7 +22,7 @@ public interface IntegrationData {
 
     String type();
 
-    boolean enabled();
+    Possible<Boolean> enabled();
 
     Possible<Boolean> syncing();
 


### PR DESCRIPTION
This fix #118 since discord make the field enabled optional.

Based in https://github.com/discord/discord-api-docs/commit/3d05c09d8858542c802d2fe281d8463f89e4e93a