### PR TITLE
Make Flags related to UserData support big numbers

### DIFF
--- a/src/main/java/discord4j/discordjson/json/PartialUserData.java
+++ b/src/main/java/discord4j/discordjson/json/PartialUserData.java
@@ -44,11 +44,11 @@ public interface PartialUserData {
 
     Possible<String> email();
 
-    Possible<Integer> flags();
+    Possible<Long> flags();
 
     @JsonProperty("premium_type")
     Possible<Integer> premiumType();
 
     @JsonProperty("public_flags")
-    Possible<Integer> publicFlags();
+    Possible<Long> publicFlags();
 }

--- a/src/main/java/discord4j/discordjson/json/UserData.java
+++ b/src/main/java/discord4j/discordjson/json/UserData.java
@@ -44,11 +44,11 @@ public interface UserData {
 
     Possible<Optional<String>> email();
 
-    Possible<Integer> flags();
+    Possible<Long> flags();
 
     @JsonProperty("premium_type")
     Possible<Integer> premiumType();
 
     @JsonProperty("public_flags")
-    Possible<Integer> publicFlags();
+    Possible<Long> publicFlags();
 }


### PR DESCRIPTION
Based in https://github.com/Discord4J/Discord4J/issues/1086 the flags can not be considered a Intenger for a few cases, this PR change the type to long for avoid this issues.