### PR TITLE
Make ListThreadsData#hasMore() compatible with all methods

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ListThreadsData.java
+++ b/src/main/java/discord4j/discordjson/json/ListThreadsData.java
@@ -3,6 +3,7 @@ package discord4j.discordjson.json;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.util.List;
@@ -21,5 +22,5 @@ public interface ListThreadsData {
     List<ThreadMemberData> members();
 
     @JsonProperty("has_more")
-    boolean hasMore();
+    Possible<Boolean> hasMore();
 }


### PR DESCRIPTION
**Description:** At the moment `ListThreadData` is used only for listing methods like [list public archived threads](https://discord.com/developers/docs/resources/channel#list-public-archived-threads), but there is also a [list active guild threads
](https://discord.com/developers/docs/resources/guild#list-active-guild-threads) which doesn't provide `has_more`