### PR TITLE
Add support for channel select menus

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/ComponentData.java
@@ -56,4 +56,7 @@ public interface ComponentData {
     Possible<List<String>> values();
 
     Possible<List<SelectOptionData>> options();
+
+    @JsonProperty("channel_types")
+    Possible<List<Integer>> channelTypes();
 }


### PR DESCRIPTION
**Description:** Adds `channel_types` attribute to `ComponentData`. See https://github.com/discord/discord-api-docs/pull/5543