### PR TITLE
Add missing field in gateway event ThreadCreate

### DIFF
--- a/src/main/java/discord4j/discordjson/json/gateway/ThreadCreate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/ThreadCreate.java
@@ -1,9 +1,11 @@
 package discord4j.discordjson.json.gateway;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import discord4j.discordjson.json.ChannelData;
+import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -17,4 +19,8 @@ public interface ThreadCreate extends Dispatch {
 
     @JsonUnwrapped
     ChannelData thread();
+
+    @JsonProperty("newly_created")
+    Possible<Boolean> newlyCreated();
+
 }

--- a/src/main/java/discord4j/discordjson/json/gateway/ThreadMembersUpdate.java
+++ b/src/main/java/discord4j/discordjson/json/gateway/ThreadMembersUpdate.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import discord4j.discordjson.Id;
 import discord4j.discordjson.json.ThreadMemberData;
+import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.util.List;
@@ -27,8 +28,8 @@ public interface ThreadMembersUpdate extends Dispatch {
     int memberCount();
 
     @JsonProperty("added_members")
-    List<ThreadMemberData> addedMembers();
+    Possible<List<ThreadMemberData>> addedMembers();
 
     @JsonProperty("removed_member_ids")
-    List<Id> removedMemberIds();
+    Possible<List<Id>> removedMemberIds();
 }


### PR DESCRIPTION
When implementing entities Store in Discord4J, I needed the `newly_created` field to know if I need to upsert the thread or update the member list.

This PR adds this missing field in ThreadCreate.java.

