### PR TITLE
Add forum missing fields in channel related requests

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ChannelCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ChannelCreateRequest.java
@@ -18,17 +18,47 @@ public interface ChannelCreateRequest {
     }
 
     String name();
+
     Possible<Integer> type();
+
     Possible<String> topic();
+
     Possible<Integer> bitrate();
+
     @JsonProperty("user_limit")
     Possible<Integer> userLimit();
+
     @JsonProperty("rate_limit_per_user")
     Possible<Integer> rateLimitPerUser();
+
     Possible<Integer> position();
+
     @JsonProperty("permission_overwrites")
     Possible<List<OverwriteData>> permissionOverwrites();
+
     @JsonProperty("parent_id")
     Possible<String> parentId();
+
     Possible<Boolean> nsfw();
+
+    @JsonProperty("default_thread_rate_limit_per_user")
+    Possible<Integer> defaultThreadRateLimitPerUser();
+
+    Possible<Integer> flags();
+
+    @JsonProperty("default_auto_archive_duration")
+    Possible<Integer> defaultAutoArchiveDuration();
+
+    @JsonProperty("default_reaction_emoji")
+    Possible<DefaultReactionData> defaultReactionEmoji();
+
+    @JsonProperty("available_tags")
+    Possible<List<ForumTagData>> availableTags();
+
+    @JsonProperty("default_sort_order")
+    Possible<Integer> defaultSortOrder();
+
+    @JsonProperty("default_forum_layout")
+    Possible<Integer> defaultForumLayout();
+
 }

--- a/src/main/java/discord4j/discordjson/json/ChannelCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ChannelCreateRequest.java
@@ -7,6 +7,7 @@ import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
 import java.util.List;
+import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableChannelCreateRequest.class)
@@ -47,18 +48,18 @@ public interface ChannelCreateRequest {
     Possible<Integer> flags();
 
     @JsonProperty("default_auto_archive_duration")
-    Possible<Integer> defaultAutoArchiveDuration();
+    Possible<Optional<Integer>> defaultAutoArchiveDuration();
 
     @JsonProperty("default_reaction_emoji")
-    Possible<DefaultReactionData> defaultReactionEmoji();
+    Possible<Optional<DefaultReactionData>> defaultReactionEmoji();
 
     @JsonProperty("available_tags")
     Possible<List<ForumTagData>> availableTags();
 
     @JsonProperty("default_sort_order")
-    Possible<Integer> defaultSortOrder();
+    Possible<Optional<Integer>> defaultSortOrder();
 
     @JsonProperty("default_forum_layout")
-    Possible<Integer> defaultForumLayout();
+    Possible<Optional<Integer>> defaultForumLayout();
 
 }

--- a/src/main/java/discord4j/discordjson/json/ChannelCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ChannelCreateRequest.java
@@ -54,7 +54,7 @@ public interface ChannelCreateRequest {
     Possible<Optional<DefaultReactionData>> defaultReactionEmoji();
 
     @JsonProperty("available_tags")
-    Possible<List<ForumTagData>> availableTags();
+    Possible<List<ForumTagParamsData>> availableTags();
 
     @JsonProperty("default_sort_order")
     Possible<Optional<Integer>> defaultSortOrder();

--- a/src/main/java/discord4j/discordjson/json/ChannelModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ChannelModifyRequest.java
@@ -45,4 +45,25 @@ public interface ChannelModifyRequest {
 
     @JsonProperty("video_quality_mode")
     Possible<Optional<Integer>> videoQualityMode();
+
+    @JsonProperty("default_auto_archive_duration")
+    Possible<Integer> defaultAutoArchiveDuration();
+
+    Possible<Integer> flags();
+
+
+    @JsonProperty("default_thread_rate_limit_per_user")
+    Possible<Integer> defaultThreadRateLimitPerUser();
+
+    @JsonProperty("default_reaction_emoji")
+    Possible<DefaultReactionData> defaultReactionEmoji();
+
+    @JsonProperty("available_tags")
+    Possible<List<ForumTagData>> availableTags();
+
+    @JsonProperty("default_sort_order")
+    Possible<Integer> defaultSortOrder();
+
+    @JsonProperty("default_forum_layout")
+    Possible<Integer> defaultForumLayout();
 }

--- a/src/main/java/discord4j/discordjson/json/ChannelModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ChannelModifyRequest.java
@@ -46,24 +46,23 @@ public interface ChannelModifyRequest {
     @JsonProperty("video_quality_mode")
     Possible<Optional<Integer>> videoQualityMode();
 
-    @JsonProperty("default_auto_archive_duration")
-    Possible<Integer> defaultAutoArchiveDuration();
-
-    Possible<Integer> flags();
-
-
     @JsonProperty("default_thread_rate_limit_per_user")
     Possible<Integer> defaultThreadRateLimitPerUser();
 
+    @JsonProperty("default_auto_archive_duration")
+    Possible<Optional<Integer>> defaultAutoArchiveDuration();
+
+    Possible<Integer> flags();
+
     @JsonProperty("default_reaction_emoji")
-    Possible<DefaultReactionData> defaultReactionEmoji();
+    Possible<Optional<DefaultReactionData>> defaultReactionEmoji();
 
     @JsonProperty("available_tags")
     Possible<List<ForumTagData>> availableTags();
 
     @JsonProperty("default_sort_order")
-    Possible<Integer> defaultSortOrder();
+    Possible<Optional<Integer>> defaultSortOrder();
 
     @JsonProperty("default_forum_layout")
-    Possible<Integer> defaultForumLayout();
+    Possible<Optional<Integer>> defaultForumLayout();
 }

--- a/src/main/java/discord4j/discordjson/json/ChannelModifyRequest.java
+++ b/src/main/java/discord4j/discordjson/json/ChannelModifyRequest.java
@@ -58,7 +58,7 @@ public interface ChannelModifyRequest {
     Possible<Optional<DefaultReactionData>> defaultReactionEmoji();
 
     @JsonProperty("available_tags")
-    Possible<List<ForumTagData>> availableTags();
+    Possible<List<ForumTagParamsData>> availableTags();
 
     @JsonProperty("default_sort_order")
     Possible<Optional<Integer>> defaultSortOrder();

--- a/src/main/java/discord4j/discordjson/json/ForumTagParamsData.java
+++ b/src/main/java/discord4j/discordjson/json/ForumTagParamsData.java
@@ -1,0 +1,33 @@
+package discord4j.discordjson.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ * Immutable tag parameters sent along with create and update requests regarding forum channels
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableForumTagParamsData.class)
+@JsonDeserialize(as = ImmutableForumTagParamsData.class)
+public interface ForumTagParamsData {
+
+    static ImmutableForumTagParamsData.Builder builder() {
+        return ImmutableForumTagParamsData.builder();
+    }
+
+    String name();
+
+    Possible<Boolean> moderated();
+
+    @JsonProperty("emoji_id")
+    Possible<Optional<Id>> emojiId();
+
+    @JsonProperty("emoji_name")
+    Possible<Optional<String>> emojiName();
+}


### PR DESCRIPTION
Hello,

To implement Forum channels in Discord4J Core and rest, I need to specify additionnal fields in ChannelCreateRequest and ChannelModifyRequest.

I made the following update to add required fields for my implementation.

This change targets 3.3.X only.