### PR TITLE
Fix missing JsonProperty annotation in guild event create request

### DIFF
--- a/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
+++ b/src/main/java/discord4j/discordjson/json/GuildScheduledEventCreateRequest.java
@@ -39,5 +39,6 @@ public interface GuildScheduledEventCreateRequest {
 
     Possible<String> description();
 
+    @JsonProperty("entity_type")
     int entityType();
 }


### PR DESCRIPTION
**Description:** This PR fixes a JSON serialization issue where `entity_type` was serialized in camel case instead of snake case.

This PR fixes the issue by adding the correct `@JsonProperty` annotation.

**Justification:** Required for https://github.com/Discord4J/Discord4J/pull/1134