### PR TITLE
Fixed guild object mapping from oauth2 flow

### DIFF
--- a/src/main/java/discord4j/discordjson/json/AccessTokenData.java
+++ b/src/main/java/discord4j/discordjson/json/AccessTokenData.java
@@ -24,7 +24,7 @@ public interface AccessTokenData {
     @JsonProperty("expires_in")
     long expiresIn();
 
-    Possible<GuildData> guild();
+    Possible<GuildUpdateData> guild();
 
     @JsonProperty("refresh_token")
     Possible<String> refreshToken();


### PR DESCRIPTION
When retrieving a discord guild with an access token, discord returns a GuildUpdateData object, not a GuildData one https://discord.com/developers/docs/topics/oauth2#advanced-bot-authorization-extended-bot-authorization-access-token-example