### PR TITLE
Added missing fields "duration_secs", "waveform" and "flags" to AttachmentData

### DIFF
--- a/src/main/java/discord4j/discordjson/json/AttachmentData.java
+++ b/src/main/java/discord4j/discordjson/json/AttachmentData.java
@@ -39,4 +39,11 @@ public interface AttachmentData {
     Possible<Optional<Integer>> width();
 
     Possible<Boolean> ephemeral();
+
+    @JsonProperty("duration_secs")
+    Possible<Float> durationSeconds();
+
+    Possible<String> waveform();
+
+    Possible<Integer> flags();
 }


### PR DESCRIPTION
Merged in discord docs by https://github.com/discord/discord-api-docs/pull/6272

https://github.com/discord/discord-api-docs/pull/6082/files