### PR TITLE
[ci skip] Improvement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # discord-json
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.discord4j/discord-json.svg?style=flat-square)](https://search.maven.org/artifact/com.discord4j/discord-json)
-[![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/Discord4J/discord-json/Java%20CI/master?logo=github&style=flat-square)](https://github.com/Discord4J/discord-json/actions)
+[![Maven Central](https://img.shields.io/maven-central/v/com.discord4j/discord-json.svg?versionPrefix=1.6&style=flat-square)](https://search.maven.org/artifact/com.discord4j/discord-json)
+[![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/Discord4J/discord-json/gradle.yml?branch=1.6.x&logo=github&style=flat-square)](https://github.com/Discord4J/discord-json/actions)
 
 Discord entity domain now available as [immutable](https://immutables.github.io/) [Jackson](https://github.com/FasterXML/jackson-databind) objects. Building this project requires JDK 11.


### PR DESCRIPTION
This make the badges in README of 1.6.x works and get the data from the version related to the branch. 