### PR TITLE
Update resolved data structure in application command interactions

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ResolvedChannelData.java
+++ b/src/main/java/discord4j/discordjson/json/ResolvedChannelData.java
@@ -2,7 +2,10 @@ package discord4j.discordjson.json;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
+
+import java.util.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableResolvedChannelData.class)
@@ -15,10 +18,12 @@ public interface ResolvedChannelData {
 
     String id();
 
-    String name();
+    // This field can be given in a resolved channel data object, but it has the same properties as the channel object
+    Possible<Optional<String>> name();
 
     int type();
 
-    String permissions();
+    // This field can be given in a resolved channel data object, but it has the same properties as the channel object
+    Possible<Optional<String>> permissions();
 
 }

--- a/src/main/java/discord4j/discordjson/json/ResolvedChannelData.java
+++ b/src/main/java/discord4j/discordjson/json/ResolvedChannelData.java
@@ -1,7 +1,9 @@
 package discord4j.discordjson.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
 import discord4j.discordjson.possible.Possible;
 import org.immutables.value.Value;
 
@@ -25,5 +27,14 @@ public interface ResolvedChannelData {
 
     // This field can be given in a resolved channel data object, but it has the same properties as the channel object
     Possible<Optional<String>> permissions();
+
+    // Only provided if channel is a thread
+    @JsonProperty("thread_metadata")
+    Possible<ThreadMetadata> threadMetadata();
+
+    // Only provided if channel is a thread
+
+    @JsonProperty("parent_id")
+    Possible<Id> parentId();
 
 }

--- a/src/main/java/discord4j/discordjson/json/ResolvedMemberData.java
+++ b/src/main/java/discord4j/discordjson/json/ResolvedMemberData.java
@@ -20,6 +20,8 @@ public interface ResolvedMemberData {
 
     Possible<Optional<String>> nick();
 
+    Possible<Optional<String>> avatar();
+
     List<String> roles();
 
     @JsonProperty("joined_at")


### PR DESCRIPTION
Re-created from #161 

*Justification:* I think there was a misunderstanding in https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure. 

> Partial Channel objects only have id, name, type and permissions fields. Threads will also have thread_metadata and parent_id fields.

Those fields in partial channel objects may be included, but they are not mandatory. They do have the same properties as in the channel object description.

This PR also includes the thread related fields, as they are missing. 

This PR is required to fix issue #1171 in D4J.