### PR TITLE
fix: ApplicationInfoData optional fields

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ApplicationInfoData.java
+++ b/src/main/java/discord4j/discordjson/json/ApplicationInfoData.java
@@ -84,10 +84,10 @@ public interface ApplicationInfoData {
     Possible<List<String>> redirectUris();
 
     @JsonProperty("interactions_endpoint_url")
-    Possible<String> interactionsEndpointUrl();
+    Possible<Optional<String>> interactionsEndpointUrl(); // Use of both Possible and Optional due to https://github.com/Discord4J/Discord4J/issues/1243
 
     @JsonProperty("role_connections_verification_url")
-    Possible<String> roleConnectionsVerificationUrl();
+    Possible<Optional<String>> roleConnectionsVerificationUrl(); // Use of both Possible and Optional due to https://github.com/Discord4J/Discord4J/issues/1243
 
     Possible<List<String>> tags();
 

--- a/src/test/resources/rest/ApplicationInfoData.json
+++ b/src/test/resources/rest/ApplicationInfoData.json
@@ -55,5 +55,7 @@
         ],
         "owner_user_id": "511972282709709995"
     },
+    "interactions_endpoint_url": null,
+    "role_connections_verification_url": null,
     "verify_key": "1e0a356058d627ca38a5c8c9648818061d49e49bd9da9e3ab17d98ad4d6bg2u8"
 }


### PR DESCRIPTION
Make ApplicationInfoData#interactionsEndpointUrl and #roleConnectionsVerificationUrl return a Possible<Optional> to fix https://github.com/Discord4J/Discord4J/issues/1243