### PR TITLE
Fix ResolvedChannelData#parentId not allowing null values

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ResolvedChannelData.java
+++ b/src/main/java/discord4j/discordjson/json/ResolvedChannelData.java
@@ -34,6 +34,6 @@ public interface ResolvedChannelData {
 
     // Only provided if channel is a thread
     @JsonProperty("parent_id")
-    Possible<Id> parentId();
+    Possible<Optional<Id>> parentId();
 
 }


### PR DESCRIPTION
This allow close https://github.com/Discord4J/Discord4J/issues/1263