### PR TITLE
Fix ForumThreadMessageParamsData to correctly use AllowedMentions

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ForumThreadMessageParamsData.java
+++ b/src/main/java/discord4j/discordjson/json/ForumThreadMessageParamsData.java
@@ -23,7 +23,7 @@ public interface ForumThreadMessageParamsData {
     Possible<List<EmbedData>> embeds();
 
     @JsonProperty("allowed_mentions")
-    Possible<List<AllowedMentionsData>> allowedMentions();
+    Possible<AllowedMentionsData> allowedMentions();
 
     Possible<List<ComponentData>> components();
 


### PR DESCRIPTION
When implementing the Forum Channels, I made a mistake and the AllowedMentions object was not sent as an object but as an array of multiple AllowedMentions when starting a thread.

This issue is referenced as Discord4J/#1314.