### PR TITLE
feat: components refactor

### DIFF
--- a/src/main/java/discord4j/discordjson/json/ComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/ComponentData.java
@@ -1,99 +1,14 @@
 package discord4j.discordjson.json;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import discord4j.discordjson.Id;
+import discord4j.discordjson.json.parser.ComponentParser;
 import discord4j.discordjson.possible.Possible;
-import java.util.Optional;
-import org.immutables.value.Value;
 
-import java.util.List;
-
-@Value.Immutable
-@JsonSerialize(as = ImmutableComponentData.class)
-@JsonDeserialize(as = ImmutableComponentData.class)
+@JsonDeserialize(using = ComponentParser.class)
 public interface ComponentData {
-
-    static ImmutableComponentData.Builder builder() {
-        return ImmutableComponentData.builder();
-    }
-
-    Possible<Integer> id();
 
     int type();
 
-    Possible<List<ComponentData>> components();
+    Possible<Integer> id();
 
-    Possible<ComponentData> component();
-
-    Possible<ComponentData> accessory();
-
-    Possible<Integer> style();
-
-    Possible<Optional<String>> label();
-
-    Possible<EmojiData> emoji();
-
-    @JsonProperty("custom_id")
-    Possible<String> customId();
-
-    Possible<String> url();
-
-    Possible<Boolean> disabled();
-
-    Possible<String> placeholder();
-
-    @JsonProperty("min_values")
-    Possible<Integer> minValues();
-
-    @JsonProperty("max_values")
-    Possible<Integer> maxValues();
-
-    /* Text input only */
-    @JsonProperty("min_length")
-    Possible<Integer> minLength();
-
-    @JsonProperty("max_length")
-    Possible<Integer> maxLength();
-
-    Possible<Boolean> required();
-
-    Possible<String> value();
-
-    Possible<List<String>> values();
-
-    Possible<List<SelectOptionData>> options();
-
-    @JsonProperty("channel_types")
-    Possible<List<Integer>> channelTypes();
-
-    /* Only for user, role, mentionable and channel select menu components */
-    @JsonProperty("default_values")
-    Possible<List<SelectDefaultValueData>> defaultValues();
-
-    @JsonProperty("sku_id")
-    Possible<Id> skuId();
-
-    Possible<Integer> spacing();
-
-    Possible<Boolean> divider();
-
-    Possible<Boolean> spoiler();
-
-    @JsonProperty("accent_color")
-    Possible<Optional<Integer>> accentColor();
-
-    Possible<Optional<String>> description();
-
-    Possible<String> content();
-
-    Possible<UnfurledMediaItemData> file();
-
-    Possible<UnfurledMediaItemData> media();
-
-    Possible<List<MediaGalleryItemData>> items();
-
-    @JsonProperty("default")
-    Possible<Boolean> isDefault();
 }

--- a/src/main/java/discord4j/discordjson/json/ComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/ComponentData.java
@@ -93,4 +93,7 @@ public interface ComponentData {
     Possible<UnfurledMediaItemData> media();
 
     Possible<List<MediaGalleryItemData>> items();
+
+    @JsonProperty("default")
+    Possible<Boolean> isDefault();
 }

--- a/src/main/java/discord4j/discordjson/json/InteractionApplicationCommandCallbackData.java
+++ b/src/main/java/discord4j/discordjson/json/InteractionApplicationCommandCallbackData.java
@@ -43,7 +43,7 @@ public interface InteractionApplicationCommandCallbackData {
      */
     Possible<Integer> flags();
 
-    Possible<List<ComponentData>> components();
+    Possible<List<ComponentData>> components(); // TODO
 
     /**
      * A list of choices the user may pick in an auto-complete response

--- a/src/main/java/discord4j/discordjson/json/MediaGalleryItemData.java
+++ b/src/main/java/discord4j/discordjson/json/MediaGalleryItemData.java
@@ -2,21 +2,18 @@ package discord4j.discordjson.json;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import discord4j.discordjson.possible.Possible;
-import java.util.Optional;
+import discord4j.discordjson.json.component.attribute.ICanBeSpoiler;
+import discord4j.discordjson.json.component.attribute.ICanHaveDescription;
+import discord4j.discordjson.json.component.attribute.IHasMedia;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableMediaGalleryItemData.class)
 @JsonDeserialize(as = ImmutableMediaGalleryItemData.class)
-public interface MediaGalleryItemData {
+public interface MediaGalleryItemData extends IHasMedia, ICanHaveDescription, ICanBeSpoiler {
 
     static ImmutableMediaGalleryItemData.Builder builder() {
         return ImmutableMediaGalleryItemData.builder();
     }
-
-    UnfurledMediaItemData media();
-    Possible<Optional<String>> description();
-    Possible<Boolean> spoiler();
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/ActionRowComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ActionRowComponentData.java
@@ -1,0 +1,20 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.IHasChildsComponentData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableActionRowComponentData.class)
+@JsonDeserialize(as = ImmutableActionRowComponentData.class)
+public interface ActionRowComponentData extends ComponentData, IHasChildsComponentData {
+
+    int COMPONENT_TYPE_ID = 1;
+
+    static ImmutableActionRowComponentData.Builder builder() {
+        return ImmutableActionRowComponentData.builder();
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/ActionRowComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ActionRowComponentData.java
@@ -14,7 +14,7 @@ public interface ActionRowComponentData extends ComponentData, IHasChildsCompone
     int COMPONENT_TYPE_ID = 1;
 
     static ImmutableActionRowComponentData.Builder builder() {
-        return ImmutableActionRowComponentData.builder();
+        return ImmutableActionRowComponentData.builder().type(ActionRowComponentData.COMPONENT_TYPE_ID);
     }
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/ButtonComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ButtonComponentData.java
@@ -1,0 +1,35 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.EmojiData;
+import discord4j.discordjson.json.component.attribute.ICanBeDisabled;
+import discord4j.discordjson.json.component.attribute.ICanHaveCustomId;
+import discord4j.discordjson.json.component.attribute.IHasStyle;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableButtonComponentData.class)
+@JsonDeserialize(as = ImmutableButtonComponentData.class)
+public interface ButtonComponentData extends ComponentData, ICanHaveCustomId, ICanBeDisabled, IHasStyle {
+
+    int COMPONENT_TYPE_ID = 2;
+
+    static ImmutableButtonComponentData.Builder builder() {
+        return ImmutableButtonComponentData.builder();
+    }
+
+    Possible<String> label();
+
+    Possible<EmojiData> emoji();
+
+    Possible<String> url();
+
+    @JsonProperty("sku_id")
+    Possible<Id> skuId();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/ButtonComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ButtonComponentData.java
@@ -20,7 +20,7 @@ public interface ButtonComponentData extends ComponentData, ICanHaveCustomId, IC
     int COMPONENT_TYPE_ID = 2;
 
     static ImmutableButtonComponentData.Builder builder() {
-        return ImmutableButtonComponentData.builder();
+        return ImmutableButtonComponentData.builder().type(ButtonComponentData.COMPONENT_TYPE_ID);
     }
 
     Possible<String> label();

--- a/src/main/java/discord4j/discordjson/json/component/ChannelSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ChannelSelectComponentData.java
@@ -1,0 +1,26 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.component.type.SelectComponentData;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableStringSelectComponentData.class)
+@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+public interface ChannelSelectComponentData extends SelectComponentData {
+
+    int COMPONENT_TYPE_ID = 8;
+
+    static ImmutableStringSelectComponentData.Builder builder() {
+        return ImmutableStringSelectComponentData.builder();
+    }
+
+    @JsonProperty("channel_types")
+    Possible<List<Integer>> channelTypes();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/ChannelSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ChannelSelectComponentData.java
@@ -10,14 +10,14 @@ import org.immutables.value.Value;
 import java.util.List;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableStringSelectComponentData.class)
-@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+@JsonSerialize(as = ImmutableChannelSelectComponentData.class)
+@JsonDeserialize(as = ImmutableChannelSelectComponentData.class)
 public interface ChannelSelectComponentData extends SelectComponentData {
 
     int COMPONENT_TYPE_ID = 8;
 
-    static ImmutableStringSelectComponentData.Builder builder() {
-        return ImmutableStringSelectComponentData.builder();
+    static ImmutableChannelSelectComponentData.Builder builder() {
+        return ImmutableChannelSelectComponentData.builder().type(ChannelSelectComponentData.COMPONENT_TYPE_ID);
     }
 
     @JsonProperty("channel_types")

--- a/src/main/java/discord4j/discordjson/json/component/CheckboxComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/CheckboxComponentData.java
@@ -1,0 +1,22 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeDefault;
+import discord4j.discordjson.json.component.attribute.ICanHaveValue;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCheckboxComponentData.class)
+@JsonDeserialize(as = ImmutableCheckboxComponentData.class)
+public interface CheckboxComponentData extends ComponentData, IHasCustomId, ICanBeDefault, ICanHaveValue {
+
+    int COMPONENT_TYPE_ID = 23;
+
+    static ImmutableCheckboxComponentData.Builder builder() {
+        return ImmutableCheckboxComponentData.builder();
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/CheckboxComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/CheckboxComponentData.java
@@ -16,7 +16,7 @@ public interface CheckboxComponentData extends ComponentData, IHasCustomId, ICan
     int COMPONENT_TYPE_ID = 23;
 
     static ImmutableCheckboxComponentData.Builder builder() {
-        return ImmutableCheckboxComponentData.builder();
+        return ImmutableCheckboxComponentData.builder().type(CheckboxComponentData.COMPONENT_TYPE_ID);
     }
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/CheckboxGroupComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/CheckboxGroupComponentData.java
@@ -1,0 +1,42 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeDefault;
+import discord4j.discordjson.json.component.attribute.ICanBeRequired;
+import discord4j.discordjson.json.component.attribute.ICanHaveDescription;
+import discord4j.discordjson.json.component.attribute.ICanHaveRangedValueCount;
+import discord4j.discordjson.json.component.attribute.ICanHaveValues;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import discord4j.discordjson.json.component.attribute.IHasLabel;
+import discord4j.discordjson.json.component.attribute.IHaveValue;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableCheckboxGroupComponentData.class)
+@JsonDeserialize(as = ImmutableCheckboxGroupComponentData.class)
+public interface CheckboxGroupComponentData extends ComponentData, IHasCustomId, ICanBeRequired, ICanHaveRangedValueCount, ICanHaveValues {
+
+    int COMPONENT_TYPE_ID = 22;
+
+    static ImmutableCheckboxGroupComponentData.Builder builder() {
+        return ImmutableCheckboxGroupComponentData.builder();
+    }
+
+    List<CheckboxGroupOptionData> options();
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableCheckboxGroupOptionData.class)
+    @JsonDeserialize(as = ImmutableCheckboxGroupOptionData.class)
+    interface CheckboxGroupOptionData extends IHaveValue, IHasLabel, ICanHaveDescription, ICanBeDefault {
+
+        static ImmutableCheckboxGroupOptionData.Builder builder() {
+            return ImmutableCheckboxGroupOptionData.builder();
+        }
+
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/CheckboxGroupComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/CheckboxGroupComponentData.java
@@ -23,7 +23,7 @@ public interface CheckboxGroupComponentData extends ComponentData, IHasCustomId,
     int COMPONENT_TYPE_ID = 22;
 
     static ImmutableCheckboxGroupComponentData.Builder builder() {
-        return ImmutableCheckboxGroupComponentData.builder();
+        return ImmutableCheckboxGroupComponentData.builder().type(CheckboxGroupComponentData.COMPONENT_TYPE_ID);
     }
 
     List<CheckboxGroupOptionData> options();

--- a/src/main/java/discord4j/discordjson/json/component/ContainerComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ContainerComponentData.java
@@ -1,0 +1,28 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeSpoiler;
+import discord4j.discordjson.json.component.attribute.IHasChildsComponentData;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableContainerComponentData.class)
+@JsonDeserialize(as = ImmutableContainerComponentData.class)
+public interface ContainerComponentData extends ComponentData, IHasChildsComponentData, ICanBeSpoiler {
+
+    int COMPONENT_TYPE_ID = 17;
+
+    static ImmutableContainerComponentData.Builder builder() {
+        return ImmutableContainerComponentData.builder();
+    }
+
+    @JsonProperty("accent_color")
+    Possible<Optional<Integer>> accentColor();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/ContainerComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ContainerComponentData.java
@@ -19,7 +19,7 @@ public interface ContainerComponentData extends ComponentData, IHasChildsCompone
     int COMPONENT_TYPE_ID = 17;
 
     static ImmutableContainerComponentData.Builder builder() {
-        return ImmutableContainerComponentData.builder();
+        return ImmutableContainerComponentData.builder().type(ContainerComponentData.COMPONENT_TYPE_ID);
     }
 
     @JsonProperty("accent_color")

--- a/src/main/java/discord4j/discordjson/json/component/FileComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/FileComponentData.java
@@ -1,0 +1,28 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.UnfurledMediaItemData;
+import discord4j.discordjson.json.component.attribute.ICanBeSpoiler;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableFileComponentData.class)
+@JsonDeserialize(as = ImmutableFileComponentData.class)
+public interface FileComponentData extends ComponentData, ICanBeSpoiler {
+
+    int COMPONENT_TYPE_ID = 13;
+
+    static ImmutableFileComponentData.Builder builder() {
+        return ImmutableFileComponentData.builder();
+    }
+
+    UnfurledMediaItemData file();
+
+    Possible<String> name();
+
+    Possible<Integer> size();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/FileComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/FileComponentData.java
@@ -16,7 +16,7 @@ public interface FileComponentData extends ComponentData, ICanBeSpoiler {
     int COMPONENT_TYPE_ID = 13;
 
     static ImmutableFileComponentData.Builder builder() {
-        return ImmutableFileComponentData.builder();
+        return ImmutableFileComponentData.builder().type(FileComponentData.COMPONENT_TYPE_ID);
     }
 
     UnfurledMediaItemData file();

--- a/src/main/java/discord4j/discordjson/json/component/FileUploadComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/FileUploadComponentData.java
@@ -1,0 +1,28 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.Id;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeRequired;
+import discord4j.discordjson.json.component.attribute.ICanHaveRangedValueCount;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableFileUploadComponentData.class)
+@JsonDeserialize(as = ImmutableFileUploadComponentData.class)
+public interface FileUploadComponentData extends ComponentData, IHasCustomId, ICanHaveRangedValueCount, ICanBeRequired {
+
+    int COMPONENT_TYPE_ID = 19;
+
+    static ImmutableFileUploadComponentData.Builder builder() {
+        return ImmutableFileUploadComponentData.builder();
+    }
+
+    Possible<List<Id>> values();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/FileUploadComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/FileUploadComponentData.java
@@ -20,7 +20,7 @@ public interface FileUploadComponentData extends ComponentData, IHasCustomId, IC
     int COMPONENT_TYPE_ID = 19;
 
     static ImmutableFileUploadComponentData.Builder builder() {
-        return ImmutableFileUploadComponentData.builder();
+        return ImmutableFileUploadComponentData.builder().type(FileUploadComponentData.COMPONENT_TYPE_ID);
     }
 
     Possible<List<Id>> values();

--- a/src/main/java/discord4j/discordjson/json/component/LabelComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/LabelComponentData.java
@@ -1,0 +1,23 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanHaveDescription;
+import discord4j.discordjson.json.component.attribute.IHasLabel;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLabelComponentData.class)
+@JsonDeserialize(as = ImmutableLabelComponentData.class)
+public interface LabelComponentData extends ComponentData, IHasLabel, ICanHaveDescription {
+
+    int COMPONENT_TYPE_ID = 18;
+
+    static ImmutableLabelComponentData.Builder builder() {
+        return ImmutableLabelComponentData.builder();
+    }
+
+    ComponentData component();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/LabelComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/LabelComponentData.java
@@ -15,7 +15,7 @@ public interface LabelComponentData extends ComponentData, IHasLabel, ICanHaveDe
     int COMPONENT_TYPE_ID = 18;
 
     static ImmutableLabelComponentData.Builder builder() {
-        return ImmutableLabelComponentData.builder();
+        return ImmutableLabelComponentData.builder().type(LabelComponentData.COMPONENT_TYPE_ID);
     }
 
     ComponentData component();

--- a/src/main/java/discord4j/discordjson/json/component/MediaGalleryComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/MediaGalleryComponentData.java
@@ -1,0 +1,24 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.MediaGalleryItemData;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableMediaGalleryComponentData.class)
+@JsonDeserialize(as = ImmutableMediaGalleryComponentData.class)
+public interface MediaGalleryComponentData extends ComponentData {
+
+    int COMPONENT_TYPE_ID = 12;
+
+    static ImmutableMediaGalleryComponentData.Builder builder() {
+        return ImmutableMediaGalleryComponentData.builder();
+    }
+
+    List<MediaGalleryItemData> items();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/MediaGalleryComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/MediaGalleryComponentData.java
@@ -16,7 +16,7 @@ public interface MediaGalleryComponentData extends ComponentData {
     int COMPONENT_TYPE_ID = 12;
 
     static ImmutableMediaGalleryComponentData.Builder builder() {
-        return ImmutableMediaGalleryComponentData.builder();
+        return ImmutableMediaGalleryComponentData.builder().type(MediaGalleryComponentData.COMPONENT_TYPE_ID);
     }
 
     List<MediaGalleryItemData> items();

--- a/src/main/java/discord4j/discordjson/json/component/MentionableSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/MentionableSelectComponentData.java
@@ -1,0 +1,19 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.component.type.SelectComponentData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableStringSelectComponentData.class)
+@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+public interface MentionableSelectComponentData extends SelectComponentData {
+
+    int COMPONENT_TYPE_ID = 7;
+
+    static ImmutableStringSelectComponentData.Builder builder() {
+        return ImmutableStringSelectComponentData.builder();
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/MentionableSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/MentionableSelectComponentData.java
@@ -6,14 +6,14 @@ import discord4j.discordjson.json.component.type.SelectComponentData;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableStringSelectComponentData.class)
-@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+@JsonSerialize(as = ImmutableMentionableSelectComponentData.class)
+@JsonDeserialize(as = ImmutableMentionableSelectComponentData.class)
 public interface MentionableSelectComponentData extends SelectComponentData {
 
     int COMPONENT_TYPE_ID = 7;
 
-    static ImmutableStringSelectComponentData.Builder builder() {
-        return ImmutableStringSelectComponentData.builder();
+    static ImmutableMentionableSelectComponentData.Builder builder() {
+        return ImmutableMentionableSelectComponentData.builder().type(MentionableSelectComponentData.COMPONENT_TYPE_ID);
     }
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/RadioGroupComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/RadioGroupComponentData.java
@@ -1,0 +1,41 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeDefault;
+import discord4j.discordjson.json.component.attribute.ICanBeRequired;
+import discord4j.discordjson.json.component.attribute.ICanHaveDescription;
+import discord4j.discordjson.json.component.attribute.ICanHaveValue;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import discord4j.discordjson.json.component.attribute.IHasLabel;
+import discord4j.discordjson.json.component.attribute.IHaveValue;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableRadioGroupComponentData.class)
+@JsonDeserialize(as = ImmutableRadioGroupComponentData.class)
+public interface RadioGroupComponentData extends ComponentData, IHasCustomId, ICanBeRequired, ICanHaveValue {
+
+    int COMPONENT_TYPE_ID = 21;
+
+    static ImmutableRadioGroupComponentData.Builder builder() {
+        return ImmutableRadioGroupComponentData.builder();
+    }
+
+    List<RadioGroupOptionData> options();
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableRadioGroupOptionData.class)
+    @JsonDeserialize(as = ImmutableRadioGroupOptionData.class)
+    interface RadioGroupOptionData extends IHaveValue, IHasLabel, ICanHaveDescription, ICanBeDefault {
+
+        static ImmutableRadioGroupOptionData.Builder builder() {
+            return ImmutableRadioGroupOptionData.builder();
+        }
+
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/RadioGroupComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/RadioGroupComponentData.java
@@ -22,7 +22,7 @@ public interface RadioGroupComponentData extends ComponentData, IHasCustomId, IC
     int COMPONENT_TYPE_ID = 21;
 
     static ImmutableRadioGroupComponentData.Builder builder() {
-        return ImmutableRadioGroupComponentData.builder();
+        return ImmutableRadioGroupComponentData.builder().type(RadioGroupComponentData.COMPONENT_TYPE_ID);
     }
 
     List<RadioGroupOptionData> options();

--- a/src/main/java/discord4j/discordjson/json/component/RoleSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/RoleSelectComponentData.java
@@ -1,0 +1,19 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.component.type.SelectComponentData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableStringSelectComponentData.class)
+@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+public interface RoleSelectComponentData extends SelectComponentData {
+
+    int COMPONENT_TYPE_ID = 6;
+
+    static ImmutableStringSelectComponentData.Builder builder() {
+        return ImmutableStringSelectComponentData.builder();
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/RoleSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/RoleSelectComponentData.java
@@ -6,14 +6,14 @@ import discord4j.discordjson.json.component.type.SelectComponentData;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableStringSelectComponentData.class)
-@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+@JsonSerialize(as = ImmutableRoleSelectComponentData.class)
+@JsonDeserialize(as = ImmutableRoleSelectComponentData.class)
 public interface RoleSelectComponentData extends SelectComponentData {
 
     int COMPONENT_TYPE_ID = 6;
 
-    static ImmutableStringSelectComponentData.Builder builder() {
-        return ImmutableStringSelectComponentData.builder();
+    static ImmutableRoleSelectComponentData.Builder builder() {
+        return ImmutableRoleSelectComponentData.builder().type(RoleSelectComponentData.COMPONENT_TYPE_ID);
     }
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/SectionComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/SectionComponentData.java
@@ -1,0 +1,22 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.IHasChildsComponentData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSectionComponentData.class)
+@JsonDeserialize(as = ImmutableSectionComponentData.class)
+public interface SectionComponentData extends ComponentData, IHasChildsComponentData {
+
+    int COMPONENT_TYPE_ID = 9;
+
+    static ImmutableSectionComponentData.Builder builder() {
+        return ImmutableSectionComponentData.builder();
+    }
+
+    ComponentData accessory();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/SectionComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/SectionComponentData.java
@@ -14,7 +14,7 @@ public interface SectionComponentData extends ComponentData, IHasChildsComponent
     int COMPONENT_TYPE_ID = 9;
 
     static ImmutableSectionComponentData.Builder builder() {
-        return ImmutableSectionComponentData.builder();
+        return ImmutableSectionComponentData.builder().type(SectionComponentData.COMPONENT_TYPE_ID);
     }
 
     ComponentData accessory();

--- a/src/main/java/discord4j/discordjson/json/component/SeparatorComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/SeparatorComponentData.java
@@ -1,0 +1,24 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSeparatorComponentData.class)
+@JsonDeserialize(as = ImmutableSeparatorComponentData.class)
+public interface SeparatorComponentData extends ComponentData {
+
+    int COMPONENT_TYPE_ID = 14;
+
+    static ImmutableSeparatorComponentData.Builder builder() {
+        return ImmutableSeparatorComponentData.builder();
+    }
+
+    Possible<Boolean> divider();
+
+    Possible<Integer> spacing();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/SeparatorComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/SeparatorComponentData.java
@@ -14,7 +14,7 @@ public interface SeparatorComponentData extends ComponentData {
     int COMPONENT_TYPE_ID = 14;
 
     static ImmutableSeparatorComponentData.Builder builder() {
-        return ImmutableSeparatorComponentData.builder();
+        return ImmutableSeparatorComponentData.builder().type(SeparatorComponentData.COMPONENT_TYPE_ID);
     }
 
     Possible<Boolean> divider();

--- a/src/main/java/discord4j/discordjson/json/component/StringSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/StringSelectComponentData.java
@@ -1,0 +1,42 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.EmojiData;
+import discord4j.discordjson.json.component.attribute.ICanBeDefault;
+import discord4j.discordjson.json.component.attribute.ICanHaveDescription;
+import discord4j.discordjson.json.component.attribute.IHasLabel;
+import discord4j.discordjson.json.component.attribute.IHaveValue;
+import discord4j.discordjson.json.component.type.SelectComponentDataBase;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableStringSelectComponentData.class)
+@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+public interface StringSelectComponentData extends SelectComponentDataBase {
+
+    int COMPONENT_TYPE_ID = 3;
+
+    static ImmutableStringSelectComponentData.Builder builder() {
+        return ImmutableStringSelectComponentData.builder();
+    }
+
+    List<StringSelectOptionData> options();
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableStringSelectOptionData.class)
+    @JsonDeserialize(as = ImmutableStringSelectOptionData.class)
+    interface StringSelectOptionData extends IHaveValue, IHasLabel, ICanHaveDescription, ICanBeDefault {
+
+        static ImmutableStringSelectOptionData.Builder builder() {
+            return ImmutableStringSelectOptionData.builder();
+        }
+
+        Possible<EmojiData> emoji();
+
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/StringSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/StringSelectComponentData.java
@@ -21,7 +21,7 @@ public interface StringSelectComponentData extends SelectComponentDataBase {
     int COMPONENT_TYPE_ID = 3;
 
     static ImmutableStringSelectComponentData.Builder builder() {
-        return ImmutableStringSelectComponentData.builder();
+        return ImmutableStringSelectComponentData.builder().type(StringSelectComponentData.COMPONENT_TYPE_ID);
     }
 
     List<StringSelectOptionData> options();

--- a/src/main/java/discord4j/discordjson/json/component/TextDisplayComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/TextDisplayComponentData.java
@@ -1,0 +1,21 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableTextDisplayComponentData.class)
+@JsonDeserialize(as = ImmutableTextDisplayComponentData.class)
+public interface TextDisplayComponentData extends ComponentData {
+
+    int COMPONENT_TYPE_ID = 10;
+
+    static ImmutableTextDisplayComponentData.Builder builder() {
+        return ImmutableTextDisplayComponentData.builder();
+    }
+
+    String content();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/TextDisplayComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/TextDisplayComponentData.java
@@ -13,7 +13,7 @@ public interface TextDisplayComponentData extends ComponentData {
     int COMPONENT_TYPE_ID = 10;
 
     static ImmutableTextDisplayComponentData.Builder builder() {
-        return ImmutableTextDisplayComponentData.builder();
+        return ImmutableTextDisplayComponentData.builder().type(TextDisplayComponentData.COMPONENT_TYPE_ID);
     }
 
     String content();

--- a/src/main/java/discord4j/discordjson/json/component/TextInputComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/TextInputComponentData.java
@@ -1,0 +1,33 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeRequired;
+import discord4j.discordjson.json.component.attribute.ICanHaveValue;
+import discord4j.discordjson.json.component.attribute.ICanHavePlaceholder;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import discord4j.discordjson.json.component.attribute.IHasStyle;
+import discord4j.discordjson.possible.Possible;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableTextInputComponentData.class)
+@JsonDeserialize(as = ImmutableTextInputComponentData.class)
+public interface TextInputComponentData extends ComponentData, IHasCustomId, ICanHaveValue, ICanBeRequired,
+        ICanHavePlaceholder, IHasStyle {
+
+    int COMPONENT_TYPE_ID = 4;
+
+    static ImmutableTextInputComponentData.Builder builder() {
+        return ImmutableTextInputComponentData.builder();
+    }
+
+    @JsonProperty("min_length")
+    Possible<Integer> minLength();
+
+    @JsonProperty("max_length")
+    Possible<Integer> maxLength();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/TextInputComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/TextInputComponentData.java
@@ -21,7 +21,7 @@ public interface TextInputComponentData extends ComponentData, IHasCustomId, ICa
     int COMPONENT_TYPE_ID = 4;
 
     static ImmutableTextInputComponentData.Builder builder() {
-        return ImmutableTextInputComponentData.builder();
+        return ImmutableTextInputComponentData.builder().type(TextInputComponentData.COMPONENT_TYPE_ID);
     }
 
     @JsonProperty("min_length")

--- a/src/main/java/discord4j/discordjson/json/component/ThumbnailComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ThumbnailComponentData.java
@@ -1,0 +1,22 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeSpoiler;
+import discord4j.discordjson.json.component.attribute.ICanHaveDescription;
+import discord4j.discordjson.json.component.attribute.IHasMedia;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableThumbnailComponentData.class)
+@JsonDeserialize(as = ImmutableThumbnailComponentData.class)
+public interface ThumbnailComponentData extends ComponentData, ICanHaveDescription, ICanBeSpoiler, IHasMedia {
+
+    int COMPONENT_TYPE_ID = 11;
+
+    static ImmutableThumbnailComponentData.Builder builder() {
+        return ImmutableThumbnailComponentData.builder();
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/ThumbnailComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/ThumbnailComponentData.java
@@ -16,7 +16,7 @@ public interface ThumbnailComponentData extends ComponentData, ICanHaveDescripti
     int COMPONENT_TYPE_ID = 11;
 
     static ImmutableThumbnailComponentData.Builder builder() {
-        return ImmutableThumbnailComponentData.builder();
+        return ImmutableThumbnailComponentData.builder().type(ThumbnailComponentData.COMPONENT_TYPE_ID);
     }
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/UserSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/UserSelectComponentData.java
@@ -1,0 +1,19 @@
+package discord4j.discordjson.json.component;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import discord4j.discordjson.json.component.type.SelectComponentData;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableStringSelectComponentData.class)
+@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+public interface UserSelectComponentData extends SelectComponentData {
+
+    int COMPONENT_TYPE_ID = 5;
+
+    static ImmutableStringSelectComponentData.Builder builder() {
+        return ImmutableStringSelectComponentData.builder();
+    }
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/UserSelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/UserSelectComponentData.java
@@ -6,14 +6,14 @@ import discord4j.discordjson.json.component.type.SelectComponentData;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutableStringSelectComponentData.class)
-@JsonDeserialize(as = ImmutableStringSelectComponentData.class)
+@JsonSerialize(as = ImmutableUserSelectComponentData.class)
+@JsonDeserialize(as = ImmutableUserSelectComponentData.class)
 public interface UserSelectComponentData extends SelectComponentData {
 
     int COMPONENT_TYPE_ID = 5;
 
-    static ImmutableStringSelectComponentData.Builder builder() {
-        return ImmutableStringSelectComponentData.builder();
+    static ImmutableUserSelectComponentData.Builder builder() {
+        return ImmutableUserSelectComponentData.builder().type(UserSelectComponentData.COMPONENT_TYPE_ID);
     }
 
 }

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeDefault.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeDefault.java
@@ -1,0 +1,11 @@
+package discord4j.discordjson.json.component.attribute;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanBeDefault {
+
+    @JsonProperty("default")
+    Possible<Boolean> isDefault();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeDisabled.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeDisabled.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanBeDisabled {
+
+    Possible<Boolean> disabled();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeRequired.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeRequired.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanBeRequired {
+
+    Possible<Boolean> required();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeSpoiler.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanBeSpoiler.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanBeSpoiler {
+
+    Possible<Boolean> spoiler();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveCustomId.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveCustomId.java
@@ -1,0 +1,11 @@
+package discord4j.discordjson.json.component.attribute;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanHaveCustomId {
+
+    @JsonProperty("custom_id")
+    Possible<String> customId();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveDescription.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveDescription.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanHaveDescription {
+
+    Possible<String> description();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanHavePlaceholder.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanHavePlaceholder.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanHavePlaceholder {
+
+    Possible<String> placeholder();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveRangedValueCount.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveRangedValueCount.java
@@ -1,0 +1,14 @@
+package discord4j.discordjson.json.component.attribute;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanHaveRangedValueCount {
+
+    @JsonProperty("min_values")
+    Possible<Integer> minValues();
+
+    @JsonProperty("max_values")
+    Possible<Integer> maxValues();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveValue.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveValue.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+public interface ICanHaveValue {
+
+    Possible<String> value();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveValues.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/ICanHaveValues.java
@@ -1,0 +1,11 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.possible.Possible;
+
+import java.util.List;
+
+public interface ICanHaveValues {
+
+    Possible<List<String>> values();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHasChildsComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHasChildsComponentData.java
@@ -1,0 +1,11 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.json.ComponentData;
+
+import java.util.List;
+
+public interface IHasChildsComponentData {
+
+    List<ComponentData> components();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHasCustomId.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHasCustomId.java
@@ -1,0 +1,10 @@
+package discord4j.discordjson.json.component.attribute;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public interface IHasCustomId {
+
+    @JsonProperty("custom_id")
+    String customId();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHasLabel.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHasLabel.java
@@ -1,0 +1,7 @@
+package discord4j.discordjson.json.component.attribute;
+
+public interface IHasLabel {
+
+    String label();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHasMedia.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHasMedia.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import discord4j.discordjson.json.UnfurledMediaItemData;
+
+public interface IHasMedia {
+
+    UnfurledMediaItemData media();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHasStyle.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHasStyle.java
@@ -1,0 +1,7 @@
+package discord4j.discordjson.json.component.attribute;
+
+public interface IHasStyle {
+
+    int style();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHaveValue.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHaveValue.java
@@ -1,0 +1,7 @@
+package discord4j.discordjson.json.component.attribute;
+
+public interface IHaveValue {
+
+    String value();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/attribute/IHaveValues.java
+++ b/src/main/java/discord4j/discordjson/json/component/attribute/IHaveValues.java
@@ -1,0 +1,9 @@
+package discord4j.discordjson.json.component.attribute;
+
+import java.util.List;
+
+public interface IHaveValues {
+
+    List<String> values();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/type/SelectComponentData.java
+++ b/src/main/java/discord4j/discordjson/json/component/type/SelectComponentData.java
@@ -1,0 +1,14 @@
+package discord4j.discordjson.json.component.type;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import discord4j.discordjson.json.SelectDefaultValueData;
+import discord4j.discordjson.possible.Possible;
+
+import java.util.List;
+
+public interface SelectComponentData extends SelectComponentDataBase {
+
+    @JsonProperty("default_values")
+    Possible<List<SelectDefaultValueData>> defaultValues();
+
+}

--- a/src/main/java/discord4j/discordjson/json/component/type/SelectComponentDataBase.java
+++ b/src/main/java/discord4j/discordjson/json/component/type/SelectComponentDataBase.java
@@ -1,0 +1,12 @@
+package discord4j.discordjson.json.component.type;
+
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.ICanBeDisabled;
+import discord4j.discordjson.json.component.attribute.ICanBeRequired;
+import discord4j.discordjson.json.component.attribute.ICanHavePlaceholder;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import discord4j.discordjson.json.component.attribute.ICanHaveRangedValueCount;
+
+public interface SelectComponentDataBase extends ComponentData, IHasCustomId, ICanBeDisabled, ICanHaveRangedValueCount,
+        ICanBeRequired, ICanHavePlaceholder {
+}

--- a/src/main/java/discord4j/discordjson/json/component/type/SelectComponentDataBase.java
+++ b/src/main/java/discord4j/discordjson/json/component/type/SelectComponentDataBase.java
@@ -4,9 +4,10 @@ import discord4j.discordjson.json.ComponentData;
 import discord4j.discordjson.json.component.attribute.ICanBeDisabled;
 import discord4j.discordjson.json.component.attribute.ICanBeRequired;
 import discord4j.discordjson.json.component.attribute.ICanHavePlaceholder;
-import discord4j.discordjson.json.component.attribute.IHasCustomId;
 import discord4j.discordjson.json.component.attribute.ICanHaveRangedValueCount;
+import discord4j.discordjson.json.component.attribute.IHasCustomId;
+import discord4j.discordjson.json.component.attribute.IHaveValues;
 
 public interface SelectComponentDataBase extends ComponentData, IHasCustomId, ICanBeDisabled, ICanHaveRangedValueCount,
-        ICanBeRequired, ICanHavePlaceholder {
+        ICanBeRequired, ICanHavePlaceholder, IHaveValues {
 }

--- a/src/main/java/discord4j/discordjson/json/parser/ComponentParser.java
+++ b/src/main/java/discord4j/discordjson/json/parser/ComponentParser.java
@@ -1,0 +1,84 @@
+package discord4j.discordjson.json.parser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.ActionRowComponentData;
+import discord4j.discordjson.json.component.ButtonComponentData;
+import discord4j.discordjson.json.component.ChannelSelectComponentData;
+import discord4j.discordjson.json.component.CheckboxComponentData;
+import discord4j.discordjson.json.component.CheckboxGroupComponentData;
+import discord4j.discordjson.json.component.ContainerComponentData;
+import discord4j.discordjson.json.component.FileComponentData;
+import discord4j.discordjson.json.component.FileUploadComponentData;
+import discord4j.discordjson.json.component.LabelComponentData;
+import discord4j.discordjson.json.component.MediaGalleryComponentData;
+import discord4j.discordjson.json.component.MentionableSelectComponentData;
+import discord4j.discordjson.json.component.RadioGroupComponentData;
+import discord4j.discordjson.json.component.RoleSelectComponentData;
+import discord4j.discordjson.json.component.SectionComponentData;
+import discord4j.discordjson.json.component.SeparatorComponentData;
+import discord4j.discordjson.json.component.StringSelectComponentData;
+import discord4j.discordjson.json.component.TextDisplayComponentData;
+import discord4j.discordjson.json.component.TextInputComponentData;
+import discord4j.discordjson.json.component.ThumbnailComponentData;
+import discord4j.discordjson.json.component.UserSelectComponentData;
+
+import java.io.IOException;
+
+public class ComponentParser extends JsonDeserializer<ComponentData> {
+
+    @Override
+    public ComponentData deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        int typeId = (Integer) node.get("type").numberValue();
+
+        switch (typeId) {
+            case ActionRowComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(ActionRowComponentData.class);
+            case ButtonComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(ButtonComponentData.class);
+            case StringSelectComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(StringSelectComponentData.class);
+            case TextInputComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(TextInputComponentData.class);
+            case UserSelectComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(UserSelectComponentData.class);
+            case RoleSelectComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(RoleSelectComponentData.class);
+            case MentionableSelectComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(MentionableSelectComponentData.class);
+            case ChannelSelectComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(ChannelSelectComponentData.class);
+            case SectionComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(SectionComponentData.class);
+            case TextDisplayComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(TextDisplayComponentData.class);
+            case ThumbnailComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(ThumbnailComponentData.class);
+            case MediaGalleryComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(MediaGalleryComponentData.class);
+            case FileComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(FileComponentData.class);
+            case SeparatorComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(SeparatorComponentData.class);
+            case ContainerComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(ContainerComponentData.class);
+            case LabelComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(LabelComponentData.class);
+            case FileUploadComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(FileUploadComponentData.class);
+            case RadioGroupComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(RadioGroupComponentData.class);
+            case CheckboxGroupComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(CheckboxGroupComponentData.class);
+            case CheckboxComponentData.COMPONENT_TYPE_ID:
+                return jsonParser.readValueAs(CheckboxComponentData.class);
+            default:
+                return jsonParser.readValueAs(ComponentData.class);
+        }
+    }
+
+}

--- a/src/test/java/discord4j/discordjson/component/ActionRow.java
+++ b/src/test/java/discord4j/discordjson/component/ActionRow.java
@@ -17,6 +17,7 @@
 package discord4j.discordjson.component;
 
 import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.ActionRowComponentData;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +47,7 @@ public class ActionRow extends LayoutComponent {
      * @return An {@code ActionRow} containing the given components.
      */
     public static ActionRow of(List<? extends ActionComponent> components) {
-        return new ActionRow(ComponentData.builder()
+        return new ActionRow(ActionRowComponentData.builder()
                 .type(Type.ACTION_ROW.getValue())
                 .components(components.stream().map(MessageComponent::getData).collect(Collectors.toList()))
                 .build());

--- a/src/test/java/discord4j/discordjson/component/ActionRow.java
+++ b/src/test/java/discord4j/discordjson/component/ActionRow.java
@@ -48,7 +48,6 @@ public class ActionRow extends LayoutComponent {
      */
     public static ActionRow of(List<? extends ActionComponent> components) {
         return new ActionRow(ActionRowComponentData.builder()
-                .type(Type.ACTION_ROW.getValue())
                 .components(components.stream().map(MessageComponent::getData).collect(Collectors.toList()))
                 .build());
     }

--- a/src/test/java/discord4j/discordjson/component/Button.java
+++ b/src/test/java/discord4j/discordjson/component/Button.java
@@ -17,7 +17,8 @@
 package discord4j.discordjson.component;
 
 import discord4j.discordjson.json.ComponentData;
-import discord4j.discordjson.json.ImmutableComponentData;
+import discord4j.discordjson.json.component.ButtonComponentData;
+import discord4j.discordjson.json.component.ImmutableButtonComponentData;
 import discord4j.discordjson.possible.Possible;
 import org.jspecify.annotations.Nullable;
 
@@ -86,7 +87,7 @@ public class Button extends ActionComponent {
     }
 
     private static Button of(Style style, @Nullable String customId, @Nullable String label, @Nullable String url) {
-        ImmutableComponentData.Builder builder = ComponentData.builder()
+        ImmutableButtonComponentData.Builder builder = ImmutableButtonComponentData.builder()
                 .type(MessageComponent.Type.BUTTON.getValue())
                 .style(style.getValue());
 
@@ -112,9 +113,7 @@ public class Button extends ActionComponent {
      * @return The button's style.
      */
     public Style getStyle() {
-        return getData().style().toOptional()
-                .map(Style::of)
-                .orElseThrow(IllegalStateException::new); // style should always be present on buttons
+        return Style.of(((ButtonComponentData) getData()).style());
     }
 
     /**
@@ -123,7 +122,7 @@ public class Button extends ActionComponent {
      * @return The button's label.
      */
     public Optional<String> getLabel() {
-        return Possible.flatOpt(getData().label());
+        return ((ButtonComponentData) getData()).label().toOptional();
     }
 
     /**
@@ -132,7 +131,7 @@ public class Button extends ActionComponent {
      * @return The button's custom id.
      */
     public Optional<String> getCustomId() {
-        return getData().customId().toOptional();
+        return ((ButtonComponentData) getData()).customId().toOptional();
     }
 
     /**
@@ -141,7 +140,7 @@ public class Button extends ActionComponent {
      * @return The button's url.
      */
     public Optional<String> getUrl() {
-        return getData().url().toOptional();
+        return ((ButtonComponentData) getData()).url().toOptional();
     }
 
     /**
@@ -150,7 +149,7 @@ public class Button extends ActionComponent {
      * @return Whether the button is disabled.
      */
     public boolean isDisabled() {
-        return getData().disabled().toOptional().orElse(false);
+        return ((ButtonComponentData) getData()).disabled().toOptional().orElse(false);
     }
 
     /**
@@ -169,7 +168,7 @@ public class Button extends ActionComponent {
      * @return A new possibly disabled button with the same data as this one.
      */
     public Button disabled(boolean value) {
-        return new Button(ComponentData.builder().from(getData()).disabled(value).build());
+        return new Button(ButtonComponentData.builder().from(getData()).disabled(value).build());
     }
 
     /**

--- a/src/test/java/discord4j/discordjson/component/Button.java
+++ b/src/test/java/discord4j/discordjson/component/Button.java
@@ -88,7 +88,6 @@ public class Button extends ActionComponent {
 
     private static Button of(Style style, @Nullable String customId, @Nullable String label, @Nullable String url) {
         ImmutableButtonComponentData.Builder builder = ImmutableButtonComponentData.builder()
-                .type(MessageComponent.Type.BUTTON.getValue())
                 .style(style.getValue());
 
         if (customId != null)

--- a/src/test/java/discord4j/discordjson/component/LayoutComponent.java
+++ b/src/test/java/discord4j/discordjson/component/LayoutComponent.java
@@ -17,6 +17,7 @@
 package discord4j.discordjson.component;
 
 import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.attribute.IHasChildsComponentData;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,10 +33,10 @@ public abstract class LayoutComponent extends MessageComponent {
     }
 
     public List<MessageComponent> getChildren() {
-        return getData().components().toOptional()
-                .map(components -> components.stream()
-                        .map(MessageComponent::fromData)
-                        .collect(Collectors.toList()))
-                .orElseThrow(IllegalStateException::new); // components should always be present on a layout component
+        return ((IHasChildsComponentData) getData())
+                .components()
+                .stream()
+                .map(MessageComponent::fromData)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/discord4j/discordjson/encoding/SpecGeneratorTest.java
+++ b/src/test/java/discord4j/discordjson/encoding/SpecGeneratorTest.java
@@ -4,6 +4,8 @@ import discord4j.discordjson.component.ActionRow;
 import discord4j.discordjson.component.Button;
 import discord4j.discordjson.component.MessageComponent;
 import discord4j.discordjson.json.ComponentData;
+import discord4j.discordjson.json.component.ActionRowComponentData;
+import discord4j.discordjson.json.component.ButtonComponentData;
 import discord4j.discordjson.possible.Possible;
 import org.junit.jupiter.api.Test;
 
@@ -28,14 +30,14 @@ public class SpecGeneratorTest {
         List<ComponentData> data = spec.asRequest();
         assertEquals(1, data.size());
 
-        ComponentData actionRow = data.get(0);
+        ActionRowComponentData actionRow = (ActionRowComponentData) data.get(0);
         assertEquals(MessageComponent.Type.ACTION_ROW.getValue(), actionRow.type());
 
-        List<ComponentData> rowComponents = actionRow.components().get();
+        List<ComponentData> rowComponents = actionRow.components();
         assertEquals(1, rowComponents.size());
 
-        ComponentData button = rowComponents.get(0);
-        assertEquals("A", Possible.flatOpt(button.label()).orElse(""));
+        ButtonComponentData button = (ButtonComponentData) rowComponents.get(0);
+        assertEquals("A", button.label().toOptional().orElse(""));
         assertEquals("id1", button.customId().get());
     }
 }


### PR DESCRIPTION
Due to how discord handles components, having only one class to represents them all is reaching limits and may cause conflicts in the future.

This PR breaks this class into a class-per-type implementation, with common attributes (being disabled for instance) grouped into common interfaces.

The goal is to be able to add new components by adding their data class as a combination of already existing attributes and new ones, without risking breaking other components.